### PR TITLE
Downgrade to symfony/process 3.2 allowing this package to work with Laravel 5.4 installs.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">=7.0.0",
         "symfony/console": "~3.2",
         "tightenco/collect": "^5.4",
-        "symfony/process": "^3.3",
+        "symfony/process": "^3.2",
         "symfony/yaml": "^3.3"
     },
     "require-dev": {


### PR DESCRIPTION
Downgrade to symfony/process 3.2 allowing this package to work with Laravel 5.4 installs.