### PR TITLE
Enable global package installation

### DIFF
--- a/churn
+++ b/churn
@@ -1,6 +1,17 @@
 #!/usr/bin/env php
 <?php
-require_once 'vendor/autoload.php';
+
+if (is_file($autoload = __DIR__.'/vendor/autoload.php')) {
+    require($autoload);
+} elseif (is_file($autoload = __DIR__ . '/../../autoload.php')) {
+    require($autoload);
+} else {
+    fwrite(STDERR,
+        'You must set up the project dependencies first. Run the following command:'.PHP_EOL.
+        'composer install'.PHP_EOL
+    );
+    exit(1);
+}
 
 use Churn\Commands\ChurnCommand;
 use Symfony\Component\Console\Application;


### PR DESCRIPTION
This will make it possible to install churn with: `composer global require bmitch/churn-php`