### PR TITLE
Tweaked composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,9 @@
     "bin": [
         "churn"
     ],
-
     "require": {
-        "php": ">=7.0.0",
-        "symfony/console": "~3.2",
+        "php": "^7.0",
+        "symfony/console": "^3.2",
         "tightenco/collect": "^5.4",
         "symfony/process": "^3.2",
         "symfony/yaml": "^3.3"


### PR DESCRIPTION
Usually, it's best to put an upper bound on the PHP version. I think `^7.0` is probably best here?