### PR TITLE
Make it possible to run from global install

### DIFF
--- a/CyclomaticComplexityAssessorRunner
+++ b/CyclomaticComplexityAssessorRunner
@@ -1,6 +1,6 @@
 #!/usr/bin/env php
 <?php
-require_once 'vendor/autoload.php';
+require_once(__DIR__ . '/bootstrap.php');
 
 use Churn\Assessors\CyclomaticComplexity\CyclomaticComplexityAssessor;
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+
+if (is_file($autoload = __DIR__.'/vendor/autoload.php')) {
+    require_once($autoload);
+} elseif (is_file($autoload = __DIR__ . '/../../autoload.php')) {
+    require_once($autoload);
+} else {
+    fwrite(STDERR,
+        'You must set up the project dependencies first. Run the following command:'.PHP_EOL.
+        'composer install'.PHP_EOL
+    );
+    exit(1);
+}

--- a/churn
+++ b/churn
@@ -1,17 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-if (is_file($autoload = __DIR__.'/vendor/autoload.php')) {
-    require_once($autoload);
-} elseif (is_file($autoload = __DIR__ . '/../../autoload.php')) {
-    require_once($autoload);
-} else {
-    fwrite(STDERR,
-        'You must set up the project dependencies first. Run the following command:'.PHP_EOL.
-        'composer install'.PHP_EOL
-    );
-    exit(1);
-}
+require_once(__DIR__ . '/bootstrap.php');
 
 use Churn\Commands\ChurnCommand;
 use Symfony\Component\Console\Application;


### PR DESCRIPTION
It's already possible to install globally, but CyclomaticComplexityAssessorRunner still tries to load the wrong autoloader which results in churn just getting stuck.