### PR TITLE
Improved scoring

### DIFF
--- a/src/Configuration/Config.php
+++ b/src/Configuration/Config.php
@@ -8,7 +8,7 @@ class Config
 {
 
     const FILES_TO_SHOW = 10;
-    const MINIMUM_SCORE_TO_SHOW = 0;
+    const MINIMUM_SCORE_TO_SHOW = 0.1;
     const AMOUNT_OF_PARALLEL_JOBS = 10;
     const SHOW_COMMITS_SINCE = '10 years ago';
     const FILES_TO_IGNORE = [];
@@ -63,9 +63,9 @@ class Config
 
     /**
      * Get the minimum score a file need to display.
-     * @return integer
+     * @return float
      */
-    public function getMinScoreToShow(): int
+    public function getMinScoreToShow(): float
     {
         return $this->configuration['minScoreToShow'] ?? self::MINIMUM_SCORE_TO_SHOW;
     }
@@ -138,7 +138,7 @@ class Config
     private function validateMinScoreToShow(array $configuration)
     {
         if (array_key_exists('minScoreToShow', $configuration)) {
-            Assert::integer($configuration['minScoreToShow'], 'Minimum score to show should be an integer');
+            Assert::numeric($configuration['minScoreToShow'], 'Minimum score to show should be a number');
         }
     }
 

--- a/src/Results/Result.php
+++ b/src/Results/Result.php
@@ -64,11 +64,39 @@ class Result implements Arrayable
 
     /**
      * Calculate the score.
-     * @return integer
+     * @return float
      */
-    public function getScore(): int
+    public function getScore(int $maxCommits, int $maxComplexity): float
     {
-        return $this->getCommits() + $this->getComplexity();
+        /*
+         * Calculate the horizontal and vertical distance from the "top right"
+         * corner.
+         */
+        $horizontalDistance = $maxCommits - $this->getCommits();
+        $verticalDistance = $maxComplexity - $this->getComplexity();
+
+        /*
+         * Normalize these values over time, we first divide by the maximum
+         * values, to always end up with distances between 0 and 1.
+         */
+        $normalizedHorizontalDistance = $horizontalDistance / $maxCommits;
+        $normalizedVerticalDistance = $verticalDistance / $maxComplexity;
+
+        /*
+         * Calculate the distance of this class from the "top right" corner,
+         * using the simple formula A^2 + B^2 = C^2; or: C = sqrt(A^2 + B^2)).
+         */
+        $distanceFromTopRightCorner = sqrt(
+            $normalizedHorizontalDistance ** 2
+            + $normalizedVerticalDistance ** 2
+        );
+
+        /*
+         * The resulting value will be between 0 and sqrt(2). A short distance is bad,
+         * so in order to end up with a high score, we invert the value by
+         * subtracting it from 1.
+         */
+        return 1 - $distanceFromTopRightCorner;
     }
 
     /**
@@ -80,8 +108,7 @@ class Result implements Arrayable
         return [
             $this->getFile(),
             $this->getCommits(),
-            $this->getComplexity(),
-            $this->getScore(),
+            $this->getComplexity()
         ];
     }
 }

--- a/src/Results/Result.php
+++ b/src/Results/Result.php
@@ -3,6 +3,7 @@
 namespace Churn\Results;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Webmozart\Assert\Assert;
 
 class Result implements Arrayable
 {
@@ -68,6 +69,9 @@ class Result implements Arrayable
      */
     public function getScore(int $maxCommits, int $maxComplexity): float
     {
+        Assert::greaterThan($maxComplexity, 0);
+        Assert::greaterThan($maxCommits, 0);
+
         /*
          * Calculate the horizontal and vertical distance from the "top right"
          * corner.

--- a/tests/Unit/Configuration/ConfigTest.php
+++ b/tests/Unit/Configuration/ConfigTest.php
@@ -60,7 +60,7 @@ class ConfigTest extends BaseTestCase
         ]);
 
         $this->assertSame($filesToShow, $config->getFilesToShow());
-        $this->assertSame($minScoreToShow, $config->getMinScoreToShow());
+        $this->assertEquals($minScoreToShow, $config->getMinScoreToShow());
         $this->assertSame($parallelJobs, $config->getParallelJobs());
         $this->assertSame($commitsSince, $config->getCommitsSince());
         $this->assertSame($filesToIgnore, $config->getFilesToIgnore());

--- a/tests/Unit/Results/ResultTest.php
+++ b/tests/Unit/Results/ResultTest.php
@@ -40,7 +40,10 @@ class ResultTest extends BaseTestCase
     /** @test */
     public function it_can_calculate_the_score()
     {
-        $this->assertSame(12, $this->result->getScore());
+        $maxCommits = 10;
+        $maxComplexity = 10;
+
+        $this->assertEquals(0.41690481051547, $this->result->getScore($maxCommits, $maxComplexity));
     }
 
     /** @test */
@@ -49,8 +52,7 @@ class ResultTest extends BaseTestCase
         $this->assertSame([
                 'filename.php',
                 5,
-                7,
-                12
+                7
             ],
             $this->result->toArray()
         );

--- a/tests/Unit/Results/ResultsParserTest.php
+++ b/tests/Unit/Results/ResultsParserTest.php
@@ -47,8 +47,7 @@ class ResultsParserTest extends BaseTestCase
         $this->assertCount(1, $parsedResults);
         $this->assertSame('foo/bar/baz.php', $parsedResults[0]->getFile());
         $this->assertSame(3, $parsedResults[0]->getCommits());
-        $this->assertSame(7, $parsedResults[0]->getScore());
-        $this->assertSame(['foo/bar/baz.php', 3, 4, 7], $parsedResults[0]->toArray());
+        $this->assertSame(['foo/bar/baz.php', 3, 4], $parsedResults[0]->toArray());
     }
 
     /** @test **/
@@ -77,7 +76,6 @@ class ResultsParserTest extends BaseTestCase
         $this->assertCount(1, $parsedResults);
         $this->assertSame('foo/bar/baz.php', $parsedResults[0]->getFile());
         $this->assertSame(0, $parsedResults[0]->getCommits());
-        $this->assertSame(4, $parsedResults[0]->getScore());
-        $this->assertSame(['foo/bar/baz.php', 0, 4, 4], $parsedResults[0]->toArray());
+        $this->assertSame(['foo/bar/baz.php', 0, 4], $parsedResults[0]->toArray());
     }
 }


### PR DESCRIPTION
Hi everyone,

I picked up the work based on #97. I came up  with a calculation that to me makes a lot of sense. See `Result::getScore()` and the comments inside it.

By normalizing the scores you basically end up with coordinates in a square of 1 by 1. The scores are based on the distance of each class to the top-right corner (the "worst" classes). In the green area, the score will be between 1 and 0. In the blue area, the score will be below 0.

![diagram](https://user-images.githubusercontent.com/1193078/31181725-5af0e736-a922-11e7-9813-0d70e4811c9e.png)

I also added a CLI option to generate JSON output, since I'm working on some tool to generate a nice diagram based on the output. Right now it looks something like this:
<img width="872" alt="screen shot 2017-10-04 at 16 21 06" src="https://user-images.githubusercontent.com/1193078/31182004-005c4490-a923-11e7-8557-d6a29a79b961.png">

I'm not quite ready to open-source that tool (since it's quite crappy atm ;)). But it would help to know if you'd be okay merging my changes in. I do realize that there is at least one breaking API change (you have to provide arguments to `Result::getScore()` now). And the overall behavior has changed, meaning that values like "minimum score" have to be revised by users. However, I think it's for the better. A minimum score of 0 basically cuts of any class that is below the line in the diagram, so it's okay to ignore them. One thing we could do is add a sanity check and warn the user that the minimum score provided should be lower than 1.

I'd be happy to hear your thoughts and please let me know if anything is not up to your standard.