### PR TITLE
Keep releases lean

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+* text=auto eol=lf
+
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+CHANGELOG.md export-ignore
+churn.yml export-ignore
+codor.xml export-ignore
+CONTRIBUTING.md export-ignore
+img/ export-ignore
+LICENSE.md export-ignore
+phpcs.xml export-ignore
+phpunit.xml.dist export-ignore
+README.md export-ignore
+tests/ export-ignore


### PR DESCRIPTION
Excludes unnecessary files from releases/distributions. The `LICENSE.md` file might be excluded from that list of files, but that's up to your liking.

Is the `churn.yml`runtime relevant or is it just an example? If so it prolly should be moved into a dedicated `resources` or `example` directory.