### PR TITLE
Escape shell arguments

### DIFF
--- a/src/Factories/ProcessFactory.php
+++ b/src/Factories/ProcessFactory.php
@@ -31,8 +31,9 @@ class ProcessFactory
     public function createGitCommitProcess(File $file): ChurnProcess
     {
         $process = new Process(
-            'git -C ' . getcwd() . " log --since=\"" . $this->commitsSince .
-            "\"  --name-only --pretty=format: " . $file->getFullPath(). " | sort | uniq -c | sort -nr"
+            'git -C ' . escapeshellarg(getcwd()) . ' log --since=' . 
+            escapeshellarg($this->commitsSince) . ' --name-only --pretty=format: ' . 
+            escapeshellarg($file->getFullPath()) . ' | sort | uniq -c | sort -nr'
         );
 
         return new ChurnProcess($file, $process, 'GitCommitProcess');
@@ -48,7 +49,8 @@ class ProcessFactory
         $rootFolder = __DIR__ . '/../../bin/';
 
         $process = new Process(
-            "php {$rootFolder}CyclomaticComplexityAssessorRunner {$file->getFullPath()}"
+            'php ' . escapeshellarg($rootFolder . 'CyclomaticComplexityAssessorRunner') .
+            ' ' . escapeshellarg($file->getFullPath())
         );
 
         return new ChurnProcess($file, $process, 'CyclomaticComplexityProcess');


### PR DESCRIPTION
Sub-processed (git and php) called with variables influenced by configuration are now escaped with escapeshellarg. See #172 for details about what problems can arise without escaping.

I tested the modified code and it worked for me.