### PR TITLE
Allow symfony 3.4 lts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/console": "^4.0",
+        "symfony/console": "^3.4 || ^4.0",
         "tightenco/collect": "^5.4",
-        "symfony/process": "^4.0",
-        "symfony/yaml": "^4.0",
+        "symfony/process": "^3.4 || ^4.0",
+        "symfony/yaml": "^3.4 || ^4.0",
         "webmozart/assert": "^1.2",
         "php-di/php-di": "^5.4"
     },


### PR DESCRIPTION
Symfony 3.4 has the exact same feature set at 4.0. Since 3.4 is LTS I think it is a good idea to support it. Especially since this PR to add the support is super small. 