### PR TITLE
Enhancement: Cache dependencies installed with composer between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ php:
  - 7.2
  - nightly
 
+cache:
+ directories:
+  - $HOME/.composer/cache
+
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source --dev


### PR DESCRIPTION
This PR

* [x] caches dependencies installed with `composer` between builds on Travis