### PR TITLE
Fix composer scripts for windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,11 +50,11 @@
     },
     "scripts": {
         "test-common": [
-            "vendor/bin/parallel-lint src tests",
-            "vendor/bin/phpmd src text phpmd.xml",
-            "vendor/bin/phploc src",
-            "vendor/bin/phpcpd src",
-            "vendor/bin/phpunit --debug --coverage-clover=coverage.xml",
+            "parallel-lint src tests",
+            "phpmd src text phpmd.xml",
+            "phploc src",
+            "phpcpd src",
+            "phpunit --debug --coverage-clover=coverage.xml",
             "php bin/churn run src"
         ],
         "test-ci": [
@@ -62,14 +62,14 @@
         ],
         "test": [
             "@test-common",
-            "vendor/bin/phpcs --standard=psr2 src -spn",
-            "vendor/bin/phpcs --standard=phpcs.xml src -spn",
-            "vendor/bin/phpcs --standard=codor.xml src -spn"
+            "phpcs --standard=psr2 src -spn",
+            "phpcs --standard=phpcs.xml src -spn",
+            "phpcs --standard=codor.xml src -spn"
         ],
         "fix": [
-            "vendor/bin/phpcbf -n --standard=phpcs.xml src/",
-            "vendor/bin/phpcbf --standard=codor.xml src -spn",
-            "vendor/bin/phpcbf --standard=psr2 src -sp"
+            "phpcbf -n --standard=phpcs.xml src/",
+            "phpcbf --standard=codor.xml src -spn",
+            "phpcbf --standard=psr2 src -sp"
         ]
     }
 }

--- a/tests/Unit/Assessors/CyclomaticComplexity/CyclomaticComplexityAssessorTest.php
+++ b/tests/Unit/Assessors/CyclomaticComplexity/CyclomaticComplexityAssessorTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Churn\Tests\Assessors\CyclomaticComplexity;
+namespace Churn\Tests\Unit\Assessors\CyclomaticComplexity;
 
 use Churn\Tests\BaseTestCase;
 use Churn\Assessors\CyclomaticComplexity\CyclomaticComplexityAssessor;

--- a/tests/Unit/Factories/ProcessFactoryTest.php
+++ b/tests/Unit/Factories/ProcessFactoryTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Churn\Tests\Results;
+namespace Churn\Tests\Unit\Factories;
 
 use Churn\Configuration\Config;
 use Churn\Factories\ProcessFactory;

--- a/tests/Unit/Factories/ResultsRendererFactoryTest.php
+++ b/tests/Unit/Factories/ResultsRendererFactoryTest.php
@@ -1,6 +1,6 @@
-<?php
+<?php declare(strict_types = 1);
 
-namespace Churn\Tests\Results;
+namespace Churn\Tests\Unit\Factories;
 
 use Churn\Factories\ResultsRendererFactory;
 use Churn\Renderers\Results\ConsoleResultsRenderer;

--- a/tests/Unit/Managers/FileManagerTest.php
+++ b/tests/Unit/Managers/FileManagerTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Churn\Tests\Results;
+namespace Churn\Tests\Unit\Managers;
 
 use Churn\Configuration\Config;
 use Churn\Managers\FileManager;

--- a/tests/Unit/Renderers/Results/CsvResultsRendererTest.php
+++ b/tests/Unit/Renderers/Results/CsvResultsRendererTest.php
@@ -1,4 +1,6 @@
-<?php
+<?php declare(strict_types = 1);
+
+namespace Churn\Tests\Unit\Renderers\Results;
 
 use Churn\Renderers\Results\CsvResultsRenderer;
 use Churn\Results\Result;

--- a/tests/Unit/Renderers/Results/JsonResultsRendererTest.php
+++ b/tests/Unit/Renderers/Results/JsonResultsRendererTest.php
@@ -1,4 +1,6 @@
-<?php
+<?php declare(strict_types = 1);
+
+namespace Churn\Tests\Unit\Renderers\Results;
 
 use Churn\Results\Result;
 use Mockery as m;

--- a/tests/Unit/Results/ResultsParserTest.php
+++ b/tests/Unit/Results/ResultsParserTest.php
@@ -1,5 +1,4 @@
-<?php
-
+<?php declare(strict_types = 1);
 
 namespace Churn\Tests\Results;
 

--- a/tests/Unit/Values/FileTest.php
+++ b/tests/Unit/Values/FileTest.php
@@ -1,8 +1,6 @@
-<?php
-
+<?php declare(strict_types = 1);
 
 namespace Churn\Tests\Unit\Values;
-
 
 use Churn\Tests\BaseTestCase;
 use Churn\Values\File;


### PR DESCRIPTION
On Windows the command `composer test` produces the following error:
```
'vendor' is not recognized as an internal or external command
```
Removing *vendor/bin/* from the commands fixes this problem.

I also noticed some namespaces were wrong in the unit tests files so I fixed them.