### PR TITLE
Fix: Synchronize phpcs commands run on Travis and in composer scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ before_script:
 script:
  - composer test-ci
  - vendor/bin/phpcs --config-set ignore_warnings_on_exit 1
- - vendor/bin/phpcs --standard=psr2 src
- - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then vendor/bin/phpcs --standard=phpcs.xml src --ignore=tests/Sniffs; fi
- - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then vendor/bin/phpcs --standard=codor.xml src -spn; fi
+ - vendor/bin/phpcs --standard=psr2 src -spn
+ - vendor/bin/phpcs --standard=phpcs.xml src -spn
+ - vendor/bin/phpcs --standard=codor.xml src -spn
 
 after_success:
  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,7 @@ before_script:
 script:
  - composer test-ci
  - vendor/bin/phpcs --config-set ignore_warnings_on_exit 1
- - vendor/bin/phpcs --standard=psr2 src -spn
- - vendor/bin/phpcs --standard=phpcs.xml src -spn
- - vendor/bin/phpcs --standard=codor.xml src -spn
+ - vendor/bin/phpcs --standard=phpcs.xml -spn src/
 
 after_success:
  - bash <(curl -s https://codecov.io/bash)

--- a/composer.json
+++ b/composer.json
@@ -50,15 +50,11 @@
     ],
     "scripts": {
         "fix": [
-            "vendor/bin/phpcbf -n --standard=phpcs.xml src/",
-            "vendor/bin/phpcbf --standard=codor.xml src -spn",
-            "vendor/bin/phpcbf --standard=psr2 src -sp"
+            "vendor/bin/phpcbf --standard=phpcs.xml -spn src/"
         ],
         "test": [
             "@test-common",
-            "vendor/bin/phpcs --standard=psr2 src -spn",
-            "vendor/bin/phpcs --standard=phpcs.xml src -spn",
-            "vendor/bin/phpcs --standard=codor.xml src -spn"
+            "vendor/bin/phpcs --standard=phpcs.xml -spn src/"
         ],
         "test-ci": [
             "@test-common"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,9 @@
 <ruleset name="MyStandard">
   <description>My custom coding standard.</description>
 
+  <rule ref="codor.xml"/>
+  <rule ref="vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PSR2/ruleset.xml"/>
+
   <!-- Dock Blocks -->
   <rule ref="Squiz.Commenting.FunctionComment" />
   <rule ref="Squiz.Commenting.FunctionCommentThrowTag" />

--- a/src/Assessors/CyclomaticComplexity/CyclomaticComplexityAssessor.php
+++ b/src/Assessors/CyclomaticComplexity/CyclomaticComplexityAssessor.php
@@ -41,7 +41,7 @@ class CyclomaticComplexityAssessor
      * @param  string $contents File contents.
      * @return void
      */
-    protected function hasAtLeastOneMethod(string $contents)
+    protected function hasAtLeastOneMethod(string $contents): void
     {
         preg_match("/[ ]function[ ]/", $contents, $matches);
         if (isset($matches[0])) {
@@ -54,7 +54,7 @@ class CyclomaticComplexityAssessor
      * @param  string $contents File contents.
      * @return void
      */
-    protected function countTheIfStatements(string $contents)
+    protected function countTheIfStatements(string $contents): void
     {
         $this->score += $this->howManyPatternMatches("/[ ]if[ ]{0,}\(/", $contents);
     }
@@ -64,7 +64,7 @@ class CyclomaticComplexityAssessor
      * @param  string $contents File contents.
      * @return void
      */
-    protected function countTheElseIfStatements(string $contents)
+    protected function countTheElseIfStatements(string $contents): void
     {
         $this->score += $this->howManyPatternMatches("/else[ ]{0,}if[ ]{0,}\(/", $contents);
     }
@@ -74,7 +74,7 @@ class CyclomaticComplexityAssessor
      * @param  string $contents File contents.
      * @return void
      */
-    protected function countTheWhileLoops(string $contents)
+    protected function countTheWhileLoops(string $contents): void
     {
         $this->score += $this->howManyPatternMatches("/while[ ]{0,}\(/", $contents);
     }
@@ -84,7 +84,7 @@ class CyclomaticComplexityAssessor
      * @param  string $contents File contents.
      * @return void
      */
-    protected function countTheForLoops(string $contents)
+    protected function countTheForLoops(string $contents): void
     {
         $this->score += $this->howManyPatternMatches("/[ ]for(each){0,1}[ ]{0,}\(/", $contents);
     }
@@ -94,7 +94,7 @@ class CyclomaticComplexityAssessor
      * @param  string $contents File contents.
      * @return void
      */
-    protected function countTheCaseStatements(string $contents)
+    protected function countTheCaseStatements(string $contents): void
     {
         $this->score += $this->howManyPatternMatches("/[ ]case[ ]{1}(.*)\:/", $contents);
     }
@@ -104,7 +104,7 @@ class CyclomaticComplexityAssessor
      * @param  string $contents File contents.
      * @return void
      */
-    protected function countTheTernaryOperators(string $contents)
+    protected function countTheTernaryOperators(string $contents): void
     {
         $this->score += $this->howManyPatternMatches("/[ ]\?.*:.*;/", $contents);
     }
@@ -114,7 +114,7 @@ class CyclomaticComplexityAssessor
      * @param  string $contents File contents.
      * @return void
      */
-    protected function countTheLogicalAnds(string $contents)
+    protected function countTheLogicalAnds(string $contents): void
     {
         $this->score += $this->howManyPatternMatches("/[ ]&&[ ]/", $contents);
     }
@@ -124,7 +124,7 @@ class CyclomaticComplexityAssessor
      * @param  string $contents File contents.
      * @return void
      */
-    protected function countTheLogicalOrs(string $contents)
+    protected function countTheLogicalOrs(string $contents): void
     {
         $this->score += $this->howManyPatternMatches("/[ ]\|\|[ ]/", $contents);
     }

--- a/src/Commands/ChurnCommand.php
+++ b/src/Commands/ChurnCommand.php
@@ -60,7 +60,7 @@ class ChurnCommand extends Command
      * Configure the command
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('run')
             ->addArgument('paths', InputArgument::IS_ARRAY, 'Path to source to check.')
@@ -76,7 +76,7 @@ class ChurnCommand extends Command
      * @param  OutputInterface $output Output.
      * @return void
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $content = (string) @file_get_contents($input->getOption('configuration'));
         $config = Config::create(Yaml::parse($content) ?? []);

--- a/src/Configuration/Config.php
+++ b/src/Configuration/Config.php
@@ -120,7 +120,7 @@ class Config
      * @param array $configuration The array containing the configuration values.
      * @return void
      */
-    private function validateConfigurationValues(array $configuration)
+    private function validateConfigurationValues(array $configuration): void
     {
         $this->validateDirectoriesToScan($configuration);
         $this->validateFilesToShow($configuration);
@@ -135,7 +135,7 @@ class Config
      * @param array $configuration The array containing the configuration values.
      * @return void
      */
-    private function validateDirectoriesToScan(array $configuration)
+    private function validateDirectoriesToScan(array $configuration): void
     {
         if (array_key_exists('directoriesToScan', $configuration)) {
             Assert::allString($configuration['directoriesToScan'], 'Directories to scan should be an array of strings');
@@ -146,7 +146,7 @@ class Config
      * @param array $configuration The array containing the configuration values.
      * @return void
      */
-    private function validateFilesToShow(array $configuration)
+    private function validateFilesToShow(array $configuration): void
     {
         if (array_key_exists('filesToShow', $configuration)) {
             Assert::integer($configuration['filesToShow'], 'Files to show should be an integer');
@@ -157,7 +157,7 @@ class Config
      * @param array $configuration The array containing the configuration values.
      * @return void
      */
-    private function validateMinScoreToShow(array $configuration)
+    private function validateMinScoreToShow(array $configuration): void
     {
         if (array_key_exists('minScoreToShow', $configuration)) {
             Assert::numeric($configuration['minScoreToShow'], 'Minimum score to show should be a number');
@@ -168,7 +168,7 @@ class Config
      * @param array $configuration The array containing the configuration values.
      * @return void
      */
-    private function validateParallelJobs(array $configuration)
+    private function validateParallelJobs(array $configuration): void
     {
         if (array_key_exists('parallelJobs', $configuration)) {
             Assert::integer($configuration['parallelJobs'], 'Amount of parallel jobs should be an integer');
@@ -180,7 +180,7 @@ class Config
      * @return void
      * @throws InvalidArgumentException If date is in a bad format.
      */
-    private function validateCommitsSince(array $configuration)
+    private function validateCommitsSince(array $configuration): void
     {
         if (array_key_exists('commitsSince', $configuration)) {
             Assert::string($configuration['commitsSince'], 'Commits since should be a string');
@@ -191,7 +191,7 @@ class Config
      * @param array $configuration The array containing the configuration values.
      * @return void
      */
-    private function validateFilesToIgnore(array $configuration)
+    private function validateFilesToIgnore(array $configuration): void
     {
         if (array_key_exists('filesToIgnore', $configuration)) {
             Assert::isArray($configuration['filesToIgnore'], 'Files to ignore should be an array of strings');
@@ -202,7 +202,7 @@ class Config
      * @param array $configuration The array containing the configuration values.
      * @return void
      */
-    private function validateFileExtensions(array $configuration)
+    private function validateFileExtensions(array $configuration): void
     {
         if (array_key_exists('fileExtensions', $configuration)) {
             Assert::isArray($configuration['fileExtensions'], 'File extensions should be an array of strings');

--- a/src/Managers/FileManager.php
+++ b/src/Managers/FileManager.php
@@ -61,7 +61,7 @@ class FileManager
      * @param  string $path Path in which to look for .php files.
      * @return void
      */
-    private function getPhpFilesFromPath(string $path)
+    private function getPhpFilesFromPath(string $path): void
     {
         $directoryIterator = new RecursiveDirectoryIterator($path);
         foreach (new RecursiveIteratorIterator($directoryIterator) as $file) {

--- a/src/Managers/ProcessManager.php
+++ b/src/Managers/ProcessManager.php
@@ -59,7 +59,7 @@ class ProcessManager
      * @param integer $numberOfParallelJobs Number of parallel jobs to run.
      * @return void
      */
-    private function getProcessResults(int $numberOfParallelJobs)
+    private function getProcessResults(int $numberOfParallelJobs): void
     {
         for ($index = $this->runningProcesses->count();
              $this->filesCollection->hasFiles() > 0 && $index < $numberOfParallelJobs;

--- a/src/Processes/ChurnProcess.php
+++ b/src/Processes/ChurnProcess.php
@@ -43,7 +43,7 @@ class ChurnProcess
      * Start the process.
      * @return void
      */
-    public function start()
+    public function start(): void
     {
         $this->process->start();
     }

--- a/src/Renderers/Results/ConsoleResultsRenderer.php
+++ b/src/Renderers/Results/ConsoleResultsRenderer.php
@@ -14,7 +14,7 @@ class ConsoleResultsRenderer implements ResultsRendererInterface
      * @param ResultCollection $results Result Collection.
      * @return void
      */
-    public function render(OutputInterface $output, ResultCollection $results)
+    public function render(OutputInterface $output, ResultCollection $results): void
     {
         $output->write($this->getHeader());
 

--- a/src/Renderers/Results/CsvResultsRenderer.php
+++ b/src/Renderers/Results/CsvResultsRenderer.php
@@ -13,7 +13,7 @@ class CsvResultsRenderer implements ResultsRendererInterface
      * @param ResultCollection $results Result Collection.
      * @return void
      */
-    public function render(OutputInterface $output, ResultCollection $results)
+    public function render(OutputInterface $output, ResultCollection $results): void
     {
         $output->writeln($this->getHeader());
 

--- a/src/Renderers/Results/JsonResultsRenderer.php
+++ b/src/Renderers/Results/JsonResultsRenderer.php
@@ -14,7 +14,7 @@ class JsonResultsRenderer implements ResultsRendererInterface
      * @param ResultCollection $results Result Collection.
      * @return void
      */
-    public function render(OutputInterface $output, ResultCollection $results)
+    public function render(OutputInterface $output, ResultCollection $results): void
     {
         $data = array_map(function (array $result) {
             return [

--- a/src/Renderers/Results/ResultsRendererInterface.php
+++ b/src/Renderers/Results/ResultsRendererInterface.php
@@ -14,5 +14,5 @@ interface ResultsRendererInterface
      * @param ResultCollection $results Result Collection.
      * @return void
      */
-    public function render(OutputInterface $output, ResultCollection $results);
+    public function render(OutputInterface $output, ResultCollection $results): void;
 }

--- a/src/Results/ResultsParser.php
+++ b/src/Results/ResultsParser.php
@@ -37,7 +37,7 @@ class ResultsParser
      * @param array  $processes The processes that were executed on the file.
      * @return void
      */
-    private function parseCompletedProcessesForFile(string $file, array $processes)
+    private function parseCompletedProcessesForFile(string $file, array $processes): void
     {
         $commits = (integer) $this->parseCommits($processes['GitCommitProcess']);
         $complexity = (integer) $processes['CyclomaticComplexityProcess']->getOutput();


### PR DESCRIPTION
This PR

* [x] synchronizes the `phpcs` commands run on Travis and in `composer` scripts
* [x] moves configuration of rules into `phpcs.xml`
* [x] runs `composer fix`
* [x] manually fixes issues `phpcbf` is unable to fix