### PR TITLE
Fix: Do not use deprecated --dev option when installing dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
   - $HOME/.composer/cache
 
 install:
-  - travis_retry composer install --no-interaction --prefer-source --dev
+  - travis_retry composer install --no-interaction --prefer-source
 
 script:
  - composer test-ci


### PR DESCRIPTION
This PR

* [x] stops using the deprecated `--dev` option when installing dependencies with `composer` on Travis 

💁‍♂️ For reference, see https://travis-ci.org/bmitch/churn-php/jobs/489348488#L496-L497.