### PR TITLE
Enhancement: Prefer dependencies to be installed from dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
   - $HOME/.composer/cache
 
 install:
-  - travis_retry composer install --no-interaction --prefer-source --dev
+  - travis_retry composer install --no-interaction --dev
 
 script:
  - composer test-ci

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "slevomat/coding-standard": "^2.0"
     },
     "config": {
+        "preferred-install": "dist",
         "sort-packages": true
     },
     "autoload": {


### PR DESCRIPTION
This PR

* [x] drops the `--prefer-source` option when installing dependencies with `composer` on Travis and instead configures the preferred install method to be `dist`

💁‍♂️ This should also help speed up builds on Travis!