### PR TITLE
Fix: Drop nightly from Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
  - 7.1
  - 7.2
  - 7.3
- - nightly
 
 cache:
  directories:


### PR DESCRIPTION
This PR

* [x] drops `nightly` from the Travis build matrix as it currently resolves to unsupported `8.0-dev`

Blocks #201, #202, #203, #204, #206, #207, #208, #209.

💁‍♂️ For reference, see

* https://travis-ci.org/bmitch/churn-php/jobs/489348488#L496-L497
* https://travis-ci.org/bmitch/churn-php/jobs/490759684#L464-L475