### PR TITLE
Enhancement: Use all columns when running tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,7 @@
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="vendor/autoload.php"
     colors="true"
+    columns="max"
 >
     <testsuites>
         <testsuite>


### PR DESCRIPTION
This PR

* [x] uses all the columns when running tests