### PR TITLE
Ignore files with a score of zero

### DIFF
--- a/src/Result/ResultAccumulator.php
+++ b/src/Result/ResultAccumulator.php
@@ -48,6 +48,9 @@ class ResultAccumulator
      */
     public function add(Result $result): void
     {
+        if ($result->getPriority() === 0) {
+            return;
+        }
         $this->numberOfFiles++;
         if ($result->getCommits() > $this->maxCommits) {
             $this->maxCommits = $result->getCommits();

--- a/tests/Unit/Result/ResultAccumulatorTest.php
+++ b/tests/Unit/Result/ResultAccumulatorTest.php
@@ -88,4 +88,15 @@ class ResultAccumulatorTest extends BaseTestCase
 
         $this->assertEquals($expectedResult, $accumulator->toArray());
     }
+
+    /** @test */
+    public function it_ignores_files_with_a_score_of_zero(): void
+    {
+        $accumulator = new ResultAccumulator(10, 0.1);
+        $accumulator->add($this->mockResult(0, 1, 'file1', 0.3));
+        $accumulator->add($this->mockResult(1, 0, 'file2', 0.2));
+        $accumulator->add($this->mockResult(0, 0, 'file3', 0.1));
+
+        $this->assertEquals(0, $accumulator->getNumberOfFiles());
+    }
 }


### PR DESCRIPTION
When running Churn on a folder containing only one non-versioned PHP file (while the folder is part of a versioned project) we got this error:
```
    ___  _   _  __  __  ____  _  _     ____  _   _  ____
   / __)( )_( )(  )(  )(  _ \( \( )___(  _ \( )_( )(  _ \
  ( (__  ) _ (  )(__)(  )   / )  ((___))___/ ) _ (  )___/
   \___)(_) (_)(______)(_)\_)(_)\_)   (__)  (_) (_)(__)

    1 [->--------------------------] < 1 sec 4.0 MiB


In Assert.php line 2042:

  [InvalidArgumentException]
  Expected a value greater than 0. Got: 0


Exception trace:
  at vendor/webmozart/assert/src/Assert.php:2042
 Webmozart\Assert\Assert::reportInvalidArgument() at vendor/webmozart/assert/src/Assert.php:838
 Webmozart\Assert\Assert::greaterThan() at src/Result/Result.php:115
 Churn\Result\Result->getScore() at src/Result/ResultAccumulator.php:95
 Churn\Result\ResultAccumulator->toArray() at src/Command/RunCommand.php:185
 Churn\Command\RunCommand->writeResult() at src/Command/RunCommand.php:101
 Churn\Command\RunCommand->execute() at vendor/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at vendor/symfony/console/Application.php:1009
 Symfony\Component\Console\Application->doRunCommand() at vendor/symfony/console/Application.php:273
 Symfony\Component\Console\Application->doRun() at vendor/symfony/console/Application.php:149
 Symfony\Component\Console\Application->run() at bin/churn:18

run [-c|--configuration [CONFIGURATION]] [--format FORMAT] [-o|--output OUTPUT] [-p|--progress] [--] [<paths>...]
```