### PR TITLE
Throw error for invalid configuration path

### DIFF
--- a/phpmd.xml
+++ b/phpmd.xml
@@ -7,6 +7,7 @@
     <description>Created with the PHP Coding Standard Generator. http://edorian.github.com/php-coding-standard-generator/
     </description>
     <rule ref="rulesets/cleancode.xml/DuplicatedArrayKey"/>
+    <rule ref="rulesets/cleancode.xml/ErrorControlOperator"/>
     <rule ref="rulesets/cleancode.xml/MissingImport"/>
     <rule ref="rulesets/cleancode.xml/UndefinedVariable"/>
     <rule ref="rulesets/codesize.xml/CyclomaticComplexity"/>

--- a/src/Command/AssessComplexityCommand.php
+++ b/src/Command/AssessComplexityCommand.php
@@ -31,7 +31,7 @@ class AssessComplexityCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $file = $input->getArgument('file');
+        $file = (string) $input->getArgument('file');
         $assessor = new CyclomaticComplexityAssessor();
         $output->writeln((string) $assessor->assess($file));
 

--- a/tests/Integration/Command/RunCommandTest.php
+++ b/tests/Integration/Command/RunCommandTest.php
@@ -7,6 +7,7 @@ namespace Churn\Tests\Integration\Command;
 use Churn\Command\RunCommand;
 use Churn\Tests\BaseTestCase;
 use DI\ContainerBuilder;
+use InvalidArgumentException;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -86,5 +87,15 @@ class RunCommandTest extends BaseTestCase
             $this->assertArrayHasKey('complexity', $value);
             $this->assertArrayHasKey('score', $value);
         }
+    }
+
+    /** @test */
+    public function it_throws_for_invalid_configuration(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->commandTester->execute([
+            'paths' => [realpath(__DIR__ . '/../..')],
+            '--configuration' => 'not a valid configuration file',
+        ]);
     }
 }


### PR DESCRIPTION
Also fixes some warnings from Scrutinizer and enables a new PHPMD rule.