### PR TITLE
Test manifest.xml validity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build: box
 	$(COMPOSER_BIN) config platform.php 7.1.3 --working-dir=build/
 	$(COMPOSER_BIN) update --no-dev --no-interaction --prefer-dist --working-dir=build/
 	CHURN_VERSION=$$( $(PHP_BIN) build/bin/churn --version --no-ansi | grep -Po '(?<= )[^@]+' ) ;\
-	sed -i -e "s@dev-master@$${CHURN_VERSION}@g" build/manifest.xml
+	sed -i -e "s@0.0.0-dev@$${CHURN_VERSION}@g" build/manifest.xml
 	$(PHP_BIN) build/box.phar validate build/box.json.dist
 	$(PHP_BIN) build/box.phar compile --working-dir=build/
 

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.4",
         "mockery/mockery": "^1.2.0",
+        "phar-io/manifest": "^1.0 || ^2.0",
         "symfony/phpunit-bridge": "^5.1 || ^6.0"
     },
     "autoload": {

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phar xmlns="https://phar.io/xml/manifest/1.0">
-	<contains name="bmitch/churn-php" version="dev-master" type="application" />
+	<contains name="bmitch/churn-php" version="0.0.0-dev" type="application" />
 	<copyright>
 		<author name="Bill Mitchell" email="wkmitch@gmail.com"/>
 		<license type="MIT" url="https://github.com/bmitch/churn-php/blob/master/LICENSE.md"/>

--- a/tests/Integration/ManifestTest.php
+++ b/tests/Integration/ManifestTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Churn\Tests\Integration;
+
+use Churn\Tests\BaseTestCase;
+use PharIo\Manifest\ManifestLoader;
+
+class ManifestTest extends BaseTestCase
+{
+    /** @test */
+    public function manifest_is_valid()
+    {
+        $path = __DIR__ . '/../../manifest.xml';
+        $this->assertTrue(is_file($path), 'manifest.xml not found');
+
+        $manifest = ManifestLoader::fromFile($path);
+
+        $name = method_exists($manifest->getName(), 'asString') ? $manifest->getName()->asString() : (string) $manifest->getName();
+        $this->assertEquals('bmitch/churn-php', $name);
+        $this->assertGreaterThan(0, $manifest->getRequirements()->count());
+    }
+}


### PR DESCRIPTION
#346 has been fixed by [54dd3b7](https://github.com/bmitch/churn-php/commit/54dd3b7c2787158e8b23ac509b83e4a6edac49ea), but this PR adds tests to prevent future regressions.