### PR TITLE
Add final or abstract keyword when missing

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,4 +31,4 @@ jobs:
       - name: "Run Infection"
         run: |
           git fetch --depth=1 origin $GITHUB_BASE_REF
-          infection -j$(nproc) --logger-github --git-diff-filter=AM --git-diff-base=origin/$GITHUB_BASE_REF --ignore-msi-with-no-mutations --min-msi=85 --min-covered-msi=95
+          infection -j$(nproc) --logger-github --git-diff-filter=AM --git-diff-base=origin/$GITHUB_BASE_REF --ignore-msi-with-no-mutations --min-msi=76 --min-covered-msi=82

--- a/src/Assessor/Assessor.php
+++ b/src/Assessor/Assessor.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Churn\Assessor;
+
+/**
+ * @internal
+ */
+interface Assessor
+{
+    /**
+     * Assess a PHP file.
+     *
+     * @param string $contents The contents of a PHP file.
+     */
+    public function assess(string $contents): int;
+}

--- a/src/Assessor/CyclomaticComplexityAssessor.php
+++ b/src/Assessor/CyclomaticComplexityAssessor.php
@@ -7,7 +7,7 @@ namespace Churn\Assessor;
 /**
  * @internal
  */
-class CyclomaticComplexityAssessor
+final class CyclomaticComplexityAssessor implements Assessor
 {
     /**
      * @var array<int, int>

--- a/src/Command/AssessComplexityCommand.php
+++ b/src/Command/AssessComplexityCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Churn\Command;
 
+use Churn\Assessor\Assessor;
 use Churn\Assessor\CyclomaticComplexityAssessor;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -13,19 +14,19 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @internal
  */
-class AssessComplexityCommand extends Command
+final class AssessComplexityCommand extends Command
 {
     /**
-     * @var CyclomaticComplexityAssessor
+     * @var Assessor
      */
     private $assessor;
 
     /**
      * Class constructor.
      *
-     * @param CyclomaticComplexityAssessor $assessor The class calculating the complexity.
+     * @param Assessor $assessor The class calculating the complexity.
      */
-    public function __construct(CyclomaticComplexityAssessor $assessor)
+    public function __construct(Assessor $assessor)
     {
         parent::__construct();
 

--- a/src/Command/Helper/MaxScoreChecker.php
+++ b/src/Command/Helper/MaxScoreChecker.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Churn\Command\Helper;
 
-use Churn\Result\ResultAccumulator;
+use Churn\Result\ResultReporter;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @internal
  */
-class MaxScoreChecker
+final class MaxScoreChecker
 {
     /**
      * @var float|null
@@ -30,9 +30,9 @@ class MaxScoreChecker
     /**
      * @param InputInterface $input Input.
      * @param OutputInterface $output Output.
-     * @param ResultAccumulator $report The report containing the scores.
+     * @param ResultReporter $report The report containing the scores.
      */
-    public function isOverThreshold(InputInterface $input, OutputInterface $output, ResultAccumulator $report): bool
+    public function isOverThreshold(InputInterface $input, OutputInterface $output, ResultReporter $report): bool
     {
         $maxScore = $report->getMaxScore();
 

--- a/src/Command/Helper/ProgressBarSubscriber.php
+++ b/src/Command/Helper/ProgressBarSubscriber.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @internal
  */
-class ProgressBarSubscriber implements AfterAnalysis, AfterFileAnalysis, BeforeAnalysis
+final class ProgressBarSubscriber implements AfterAnalysis, AfterFileAnalysis, BeforeAnalysis
 {
     /**
      * @var ProgressBar

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -9,6 +9,7 @@ use Churn\Command\Helper\ProgressBarSubscriber;
 use Churn\Configuration\Config;
 use Churn\Configuration\Loader;
 use Churn\Event\Broker;
+use Churn\Event\BrokerImpl;
 use Churn\Event\Event\AfterAnalysisEvent;
 use Churn\Event\Event\BeforeAnalysisEvent;
 use Churn\Event\HookLoader;
@@ -35,7 +36,7 @@ use Webmozart\Assert\Assert;
  * @internal
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class RunCommand extends Command
+final class RunCommand extends Command
 {
     public const LOGO = "
     ___  _   _  __  __  ____  _  _     ____  _   _  ____
@@ -110,7 +111,7 @@ class RunCommand extends Command
         }
         $this->printLogo($input, $output);
         $config = $this->getConfiguration($input, $output);
-        $broker = new Broker();
+        $broker = new BrokerImpl();
         (new HookLoader($config->getDirPath()))->attachHooks($config->getHooks(), $broker);
         if (true === $input->getOption('progress')) {
             $broker->subscribe(new ProgressBarSubscriber($output));

--- a/src/Configuration/Config.php
+++ b/src/Configuration/Config.php
@@ -7,7 +7,7 @@ namespace Churn\Configuration;
 /**
  * @internal
  */
-class Config
+abstract class Config
 {
     /**
      * @var array<string>

--- a/src/Configuration/Loader.php
+++ b/src/Configuration/Loader.php
@@ -23,7 +23,7 @@ use Symfony\Component\Yaml\Yaml;
  * @internal
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Loader
+final class Loader
 {
     /**
      * @param string $confPath Path of the configuration file to load.
@@ -43,7 +43,7 @@ class Loader
         }
 
         if ($isDefaultValue) {
-            return new Config();
+            return new ReadOnlyConfig();
         }
 
         throw new InvalidArgumentException('The configuration file can not be read at ' . $originalConfPath);

--- a/src/Configuration/ReadOnlyConfig.php
+++ b/src/Configuration/ReadOnlyConfig.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Churn\Configuration;
+
+/**
+ * @internal
+ */
+final class ReadOnlyConfig extends Config
+{
+}

--- a/src/Event/Broker.php
+++ b/src/Event/Broker.php
@@ -4,74 +4,18 @@ declare(strict_types=1);
 
 namespace Churn\Event;
 
-use Churn\Event\Channel\AfterAnalysisChannel;
-use Churn\Event\Channel\AfterFileAnalysisChannel;
-use Churn\Event\Channel\BeforeAnalysisChannel;
-
 /**
  * @internal
  */
-class Broker
+interface Broker
 {
-    /**
-     * @var array<string, array<callable>>
-     * @psalm-var array<class-string, array<callable>>
-     */
-    private $subscribers = [];
-
-    /**
-     * @var array<\Churn\Event\Channel>
-     */
-    private $channels;
-
-    /**
-     * Class constructor.
-     */
-    public function __construct()
-    {
-        $this->channels = [
-            new AfterAnalysisChannel(),
-            new AfterFileAnalysisChannel(),
-            new BeforeAnalysisChannel(),
-        ];
-    }
-
     /**
      * @param object $subscriber A subscriber object.
      */
-    public function subscribe($subscriber): void
-    {
-        foreach ($this->channels as $channel) {
-            if (!$channel->accepts($subscriber)) {
-                continue;
-            }
-
-            $this->subscribers[$channel->getEventClassname()][] = $channel->buildEventHandler($subscriber);
-        }
-    }
+    public function subscribe($subscriber): void;
 
     /**
      * @param Event $event The triggered event.
      */
-    public function notify(Event $event): void
-    {
-        foreach ($this->subscribers as $eventClass => $subscribers) {
-            if (!$event instanceof $eventClass) {
-                continue;
-            }
-
-            $this->notifyAll($event, $subscribers);
-        }
-    }
-
-    /**
-     * @param Event $event The triggered event.
-     * @param array<callable> $subscribers The subscribers to notify.
-     */
-    private function notifyAll(Event $event, array $subscribers): void
-    {
-        foreach ($subscribers as $subscriber) {
-            $subscriber($event);
-        }
-    }
+    public function notify(Event $event): void;
 }

--- a/src/Event/BrokerImpl.php
+++ b/src/Event/BrokerImpl.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Churn\Event;
+
+use Churn\Event\Channel\AfterAnalysisChannel;
+use Churn\Event\Channel\AfterFileAnalysisChannel;
+use Churn\Event\Channel\BeforeAnalysisChannel;
+
+/**
+ * @internal
+ */
+final class BrokerImpl implements Broker
+{
+    /**
+     * @var array<string, array<callable>>
+     * @psalm-var array<class-string, array<callable>>
+     */
+    private $subscribers = [];
+
+    /**
+     * @var array<\Churn\Event\Channel>
+     */
+    private $channels;
+
+    /**
+     * Class constructor.
+     */
+    public function __construct()
+    {
+        $this->channels = [
+            new AfterAnalysisChannel(),
+            new AfterFileAnalysisChannel(),
+            new BeforeAnalysisChannel(),
+        ];
+    }
+
+    /**
+     * @param object $subscriber A subscriber object.
+     */
+    public function subscribe($subscriber): void
+    {
+        foreach ($this->channels as $channel) {
+            if (!$channel->accepts($subscriber)) {
+                continue;
+            }
+
+            $this->subscribers[$channel->getEventClassname()][] = $channel->buildEventHandler($subscriber);
+        }
+    }
+
+    /**
+     * @param Event $event The triggered event.
+     */
+    public function notify(Event $event): void
+    {
+        foreach ($this->subscribers as $eventClass => $subscribers) {
+            if (!$event instanceof $eventClass) {
+                continue;
+            }
+
+            $this->notifyAll($event, $subscribers);
+        }
+    }
+
+    /**
+     * @param Event $event The triggered event.
+     * @param array<callable> $subscribers The subscribers to notify.
+     */
+    private function notifyAll(Event $event, array $subscribers): void
+    {
+        foreach ($subscribers as $subscriber) {
+            $subscriber($event);
+        }
+    }
+}

--- a/src/Event/Event/AfterAnalysisEvent.php
+++ b/src/Event/Event/AfterAnalysisEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Churn\Event\Event;
 
-use Churn\Result\ResultAccumulator;
+use Churn\Result\ResultReporter;
 
 /**
  * @internal
@@ -12,16 +12,16 @@ use Churn\Result\ResultAccumulator;
 final class AfterAnalysisEvent implements AfterAnalysis
 {
     /**
-     * @var ResultAccumulator
+     * @var ResultReporter
      */
-    private $resultAccumulator;
+    private $resultReporter;
 
     /**
-     * @param ResultAccumulator $resultAccumulator The results report.
+     * @param ResultReporter $resultReporter The results report.
      */
-    public function __construct(ResultAccumulator $resultAccumulator)
+    public function __construct(ResultReporter $resultReporter)
     {
-        $this->resultAccumulator = $resultAccumulator;
+        $this->resultReporter = $resultReporter;
     }
 
     /**
@@ -29,7 +29,7 @@ final class AfterAnalysisEvent implements AfterAnalysis
      */
     public function getNumberOfFiles(): int
     {
-        return $this->resultAccumulator->getNumberOfFiles();
+        return $this->resultReporter->getNumberOfFiles();
     }
 
     /**
@@ -37,7 +37,7 @@ final class AfterAnalysisEvent implements AfterAnalysis
      */
     public function getMaxNumberOfChanges(): int
     {
-        return $this->resultAccumulator->getMaxCommits();
+        return $this->resultReporter->getMaxCommits();
     }
 
     /**
@@ -45,7 +45,7 @@ final class AfterAnalysisEvent implements AfterAnalysis
      */
     public function getMaxCyclomaticComplexity(): int
     {
-        return $this->resultAccumulator->getMaxComplexity();
+        return $this->resultReporter->getMaxComplexity();
     }
 
     /**
@@ -53,6 +53,6 @@ final class AfterAnalysisEvent implements AfterAnalysis
      */
     public function getMaxScore(): ?float
     {
-        return $this->resultAccumulator->getMaxScore();
+        return $this->resultReporter->getMaxScore();
     }
 }

--- a/src/Event/Event/AfterFileAnalysisEvent.php
+++ b/src/Event/Event/AfterFileAnalysisEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Churn\Event\Event;
 
-use Churn\Result\Result;
+use Churn\Result\ResultInterface;
 
 /**
  * @internal
@@ -12,14 +12,14 @@ use Churn\Result\Result;
 final class AfterFileAnalysisEvent implements AfterFileAnalysis
 {
     /**
-     * @var Result
+     * @var ResultInterface
      */
     private $result;
 
     /**
-     * @param Result $result The result for a file.
+     * @param ResultInterface $result The result for a file.
      */
-    public function __construct(Result $result)
+    public function __construct(ResultInterface $result)
     {
         $this->result = $result;
     }
@@ -27,7 +27,7 @@ final class AfterFileAnalysisEvent implements AfterFileAnalysis
     /**
      * Returns the result for a file.
      */
-    public function getResult(): Result
+    public function getResult(): ResultInterface
     {
         return $this->result;
     }

--- a/src/Event/Subscriber/AfterAnalysisHookDecorator.php
+++ b/src/Event/Subscriber/AfterAnalysisHookDecorator.php
@@ -10,7 +10,7 @@ use Churn\Event\Event\AfterAnalysis as AfterAnalysisEvent;
  * @internal
  * @implements HookDecorator<\Churn\Event\Hook\AfterAnalysisHook>
  */
-class AfterAnalysisHookDecorator implements AfterAnalysis, HookDecorator
+final class AfterAnalysisHookDecorator implements AfterAnalysis, HookDecorator
 {
     /**
      * @var string

--- a/src/Event/Subscriber/AfterFileAnalysisHookDecorator.php
+++ b/src/Event/Subscriber/AfterFileAnalysisHookDecorator.php
@@ -10,7 +10,7 @@ use Churn\Event\Event\AfterFileAnalysis as AfterFileAnalysisEvent;
  * @internal
  * @implements HookDecorator<\Churn\Event\Hook\AfterFileAnalysisHook>
  */
-class AfterFileAnalysisHookDecorator implements AfterFileAnalysis, HookDecorator
+final class AfterFileAnalysisHookDecorator implements AfterFileAnalysis, HookDecorator
 {
     /**
      * @var string

--- a/src/Event/Subscriber/BeforeAnalysisHookDecorator.php
+++ b/src/Event/Subscriber/BeforeAnalysisHookDecorator.php
@@ -10,7 +10,7 @@ use Churn\Event\Event\BeforeAnalysis as BeforeAnalysisEvent;
  * @internal
  * @implements HookDecorator<\Churn\Event\Hook\BeforeAnalysisHook>
  */
-class BeforeAnalysisHookDecorator implements BeforeAnalysis, HookDecorator
+final class BeforeAnalysisHookDecorator implements BeforeAnalysis, HookDecorator
 {
     /**
      * @var string

--- a/src/File/File.php
+++ b/src/File/File.php
@@ -7,7 +7,7 @@ namespace Churn\File;
 /**
  * @internal
  */
-class File
+final class File
 {
     /**
      * The full path of the file.

--- a/src/File/FileFinder.php
+++ b/src/File/FileFinder.php
@@ -12,7 +12,7 @@ use SplFileInfo;
 /**
  * @internal
  */
-class FileFinder
+final class FileFinder
 {
     /**
      * List of file extensions to look for.

--- a/src/File/FileHelper.php
+++ b/src/File/FileHelper.php
@@ -11,7 +11,7 @@ use Symfony\Component\Filesystem\Filesystem;
 /**
  * @internal
  */
-class FileHelper
+final class FileHelper
 {
     /**
      * @param string $path The path of an item.

--- a/src/Process/CacheProcessFactory.php
+++ b/src/Process/CacheProcessFactory.php
@@ -16,7 +16,7 @@ use Throwable;
 /**
  * @internal
  */
-class CacheProcessFactory implements AfterAnalysis, AfterFileAnalysis, ProcessFactory
+final class CacheProcessFactory implements AfterAnalysis, AfterFileAnalysis, ProcessFactory
 {
     /**
      * @var string The cache file path.

--- a/src/Process/ChangesCount/FossilChangesCountProcess.php
+++ b/src/Process/ChangesCount/FossilChangesCountProcess.php
@@ -12,7 +12,7 @@ use Symfony\Component\Process\Process;
 /**
  * @internal
  */
-class FossilChangesCountProcess extends ChurnProcess implements ChangesCountInterface
+final class FossilChangesCountProcess extends ChurnProcess implements ChangesCountInterface
 {
     /**
      * Class constructor.

--- a/src/Process/ChangesCount/GitChangesCountProcess.php
+++ b/src/Process/ChangesCount/GitChangesCountProcess.php
@@ -12,7 +12,7 @@ use Symfony\Component\Process\Process;
 /**
  * @internal
  */
-class GitChangesCountProcess extends ChurnProcess implements ChangesCountInterface
+final class GitChangesCountProcess extends ChurnProcess implements ChangesCountInterface
 {
     /**
      * Class constructor.

--- a/src/Process/ChangesCount/MercurialChangesCountProcess.php
+++ b/src/Process/ChangesCount/MercurialChangesCountProcess.php
@@ -12,7 +12,7 @@ use Symfony\Component\Process\Process;
 /**
  * @internal
  */
-class MercurialChangesCountProcess extends ChurnProcess implements ChangesCountInterface
+final class MercurialChangesCountProcess extends ChurnProcess implements ChangesCountInterface
 {
     /**
      * Class constructor.

--- a/src/Process/ChangesCount/NoVcsChangesCountProcess.php
+++ b/src/Process/ChangesCount/NoVcsChangesCountProcess.php
@@ -10,7 +10,7 @@ use Churn\Process\ChangesCountInterface;
 /**
  * @internal
  */
-class NoVcsChangesCountProcess implements ChangesCountInterface
+final class NoVcsChangesCountProcess implements ChangesCountInterface
 {
     /**
      * The file the process will be executed on.

--- a/src/Process/ChangesCount/SubversionChangesCountProcess.php
+++ b/src/Process/ChangesCount/SubversionChangesCountProcess.php
@@ -12,7 +12,7 @@ use Symfony\Component\Process\Process;
 /**
  * @internal
  */
-class SubversionChangesCountProcess extends ChurnProcess implements ChangesCountInterface
+final class SubversionChangesCountProcess extends ChurnProcess implements ChangesCountInterface
 {
     /**
      * Class constructor.

--- a/src/Process/ChangesCountProcessBuilder.php
+++ b/src/Process/ChangesCountProcessBuilder.php
@@ -18,7 +18,7 @@ use Webmozart\Assert\Assert;
 /**
  * @internal
  */
-class ChangesCountProcessBuilder
+final class ChangesCountProcessBuilder
 {
     /**
      * @param string $vcs Name of the version control system.

--- a/src/Process/ConcreteProcessFactory.php
+++ b/src/Process/ConcreteProcessFactory.php
@@ -13,7 +13,7 @@ use Symfony\Component\Process\Process;
 /**
  * @internal
  */
-class ConcreteProcessFactory implements ProcessFactory
+final class ConcreteProcessFactory implements ProcessFactory
 {
     /**
      * Builder of objects implementing ChangesCountInterface.

--- a/src/Process/CyclomaticComplexityProcess.php
+++ b/src/Process/CyclomaticComplexityProcess.php
@@ -7,7 +7,7 @@ namespace Churn\Process;
 /**
  * @internal
  */
-class CyclomaticComplexityProcess extends ChurnProcess implements CyclomaticComplexityInterface
+final class CyclomaticComplexityProcess extends ChurnProcess implements CyclomaticComplexityInterface
 {
     /**
      * Returns the cyclomatic complexity of a file.

--- a/src/Process/Handler/ParallelProcessHandler.php
+++ b/src/Process/Handler/ParallelProcessHandler.php
@@ -15,7 +15,7 @@ use Generator;
 /**
  * @internal
  */
-class ParallelProcessHandler extends BaseProcessHandler
+final class ParallelProcessHandler extends BaseProcessHandler
 {
     /**
      * Array of completed processes.

--- a/src/Process/Handler/SequentialProcessHandler.php
+++ b/src/Process/Handler/SequentialProcessHandler.php
@@ -14,7 +14,7 @@ use Generator;
 /**
  * @internal
  */
-class SequentialProcessHandler extends BaseProcessHandler
+final class SequentialProcessHandler extends BaseProcessHandler
 {
     /**
      * @var Broker

--- a/src/Process/PredefinedProcess.php
+++ b/src/Process/PredefinedProcess.php
@@ -9,7 +9,7 @@ use Churn\File\File;
 /**
  * @internal
  */
-class PredefinedProcess implements ChangesCountInterface, CyclomaticComplexityInterface
+final class PredefinedProcess implements ChangesCountInterface, CyclomaticComplexityInterface
 {
     /**
      * @var File

--- a/src/Process/ProcessHandlerFactory.php
+++ b/src/Process/ProcessHandlerFactory.php
@@ -13,7 +13,7 @@ use Churn\Process\Handler\SequentialProcessHandler;
 /**
  * @internal
  */
-class ProcessHandlerFactory
+final class ProcessHandlerFactory
 {
     /**
      * Returns a process handler depending on the configuration.

--- a/src/Result/HighestScores.php
+++ b/src/Result/HighestScores.php
@@ -9,10 +9,10 @@ use SplFixedArray;
 /**
  * @internal
  */
-class HighestScores
+final class HighestScores
 {
     /**
-     * @var SplFixedArray<Result|null>
+     * @var SplFixedArray<ResultInterface|null>
      */
     private $scores;
 
@@ -29,7 +29,7 @@ class HighestScores
     /**
      * Returns the results as a normal PHP array.
      *
-     * @return array<Result>
+     * @return array<ResultInterface>
      */
     public function toArray(): array
     {
@@ -39,9 +39,9 @@ class HighestScores
     /**
      * Add the result if its priority is high enough.
      *
-     * @param Result $result The result for a file.
+     * @param ResultInterface $result The result for a file.
      */
-    public function add(Result $result): void
+    public function add(ResultInterface $result): void
     {
         $worstScore = $this->scores[$this->scores->getSize() - 1];
         if (null !== $worstScore && $result->getPriority() <= $worstScore->getPriority()) {
@@ -54,9 +54,9 @@ class HighestScores
     /**
      * Returns the position where the result must be inserted.
      *
-     * @param Result $result The result for a file.
+     * @param ResultInterface $result The result for a file.
      */
-    private function findPosition(Result $result): int
+    private function findPosition(ResultInterface $result): int
     {
         $pos = 0;
 
@@ -74,10 +74,10 @@ class HighestScores
     /**
      * Inserts the result at a given position and shifts the lower elements.
      *
-     * @param Result $result The result for a file.
+     * @param ResultInterface $result The result for a file.
      * @param integer $position The position where the result must be inserted.
      */
-    private function insertAt(Result $result, int $position): void
+    private function insertAt(ResultInterface $result, int $position): void
     {
         for ($i = $this->scores->getSize() - 1; $i > $position; $i--) {
             $this->scores[$i] = $this->scores[$i - 1];

--- a/src/Result/Render/ConsoleResultsRenderer.php
+++ b/src/Result/Render/ConsoleResultsRenderer.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @internal
  */
-class ConsoleResultsRenderer implements ResultsRendererInterface
+final class ConsoleResultsRenderer implements ResultsRendererInterface
 {
     /**
      * Renders the results.

--- a/src/Result/Render/CsvResultsRenderer.php
+++ b/src/Result/Render/CsvResultsRenderer.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @internal
  */
-class CsvResultsRenderer implements ResultsRendererInterface
+final class CsvResultsRenderer implements ResultsRendererInterface
 {
     /**
      * Renders the results.

--- a/src/Result/Render/JsonResultsRenderer.php
+++ b/src/Result/Render/JsonResultsRenderer.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @internal
  */
-class JsonResultsRenderer implements ResultsRendererInterface
+final class JsonResultsRenderer implements ResultsRendererInterface
 {
     /**
      * Renders the results.

--- a/src/Result/Result.php
+++ b/src/Result/Result.php
@@ -10,7 +10,7 @@ use Webmozart\Assert\Assert;
 /**
  * @internal
  */
-class Result
+final class Result implements ResultInterface
 {
     /**
      * The file property.

--- a/src/Result/ResultAccumulator.php
+++ b/src/Result/ResultAccumulator.php
@@ -11,7 +11,7 @@ use Churn\Event\Subscriber\AfterFileAnalysis;
 /**
  * @internal
  */
-class ResultAccumulator implements AfterFileAnalysis
+final class ResultAccumulator implements AfterFileAnalysis, ResultReporter
 {
     /**
      * @var integer
@@ -64,9 +64,9 @@ class ResultAccumulator implements AfterFileAnalysis
     }
 
     /**
-     * @param Result $result The result for a file.
+     * @param ResultInterface $result The result for a file.
      */
-    public function add(Result $result): void
+    public function add(ResultInterface $result): void
     {
         if (0 === $result->getPriority()) {
             return;

--- a/src/Result/ResultInterface.php
+++ b/src/Result/ResultInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Churn\Result;
+
+use Churn\File\File;
+
+/**
+ * @internal
+ */
+interface ResultInterface
+{
+    /**
+     * Return the file.
+     */
+    public function getFile(): File;
+
+    /**
+     * Get the number of changes.
+     */
+    public function getCommits(): int;
+
+    /**
+     * Get the file complexity.
+     */
+    public function getComplexity(): int;
+
+    /**
+     * Get the file priority.
+     */
+    public function getPriority(): int;
+
+    /**
+     * Calculate the score.
+     *
+     * @param integer $maxCommits The highest number of commits out of any file scanned.
+     * @param integer $maxComplexity The maximum complexity out of any file scanned.
+     */
+    public function getScore(int $maxCommits, int $maxComplexity): float;
+}

--- a/src/Result/ResultReporter.php
+++ b/src/Result/ResultReporter.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Churn\Result;
+
+/**
+ * @internal
+ */
+interface ResultReporter
+{
+    /**
+     * Returns the maximum number of changes for a file.
+     */
+    public function getMaxCommits(): int;
+
+    /**
+     * Returns the maximum complexity for a file.
+     */
+    public function getMaxComplexity(): int;
+
+    /**
+     * Returns the number of files processed.
+     */
+    public function getNumberOfFiles(): int;
+
+    /**
+     * Returns the highest score.
+     */
+    public function getMaxScore(): ?float;
+}

--- a/src/Result/ResultsRendererFactory.php
+++ b/src/Result/ResultsRendererFactory.php
@@ -13,7 +13,7 @@ use InvalidArgumentException;
 /**
  * @internal
  */
-class ResultsRendererFactory
+final class ResultsRendererFactory
 {
     private const FORMAT_JSON = 'json';
     private const FORMAT_CSV = 'csv';

--- a/tests/Unit/Command/Helper/MaxScoreCheckerTest.php
+++ b/tests/Unit/Command/Helper/MaxScoreCheckerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Churn\Tests\Unit\Command\Helper;
 
 use Churn\Command\Helper\MaxScoreChecker;
-use Churn\Result\ResultAccumulator;
+use Churn\Result\ResultReporter;
 use Churn\Tests\BaseTestCase;
 use Mockery as m;
 use Symfony\Component\Console\Input\InputInterface;
@@ -32,7 +32,7 @@ class MaxScoreCheckerTest extends BaseTestCase
         $output = m::mock(OutputInterface::class);
         $output->shouldReceive('writeln');
 
-        $report = m::mock(ResultAccumulator::class);
+        $report = m::mock(ResultReporter::class);
         $report->shouldReceive('getMaxScore')->andReturn($maxScore);
 
         $checker = new MaxScoreChecker($threshold);

--- a/tests/Unit/Configuration/LoaderTest.php
+++ b/tests/Unit/Configuration/LoaderTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Churn\Tests\Unit\Configuration;
 
-use Churn\Configuration\Config;
+use Churn\Configuration\ReadOnlyConfig;
 use Churn\Configuration\EditableConfig;
 use Churn\Configuration\Loader;
 use Churn\Tests\BaseTestCase;
@@ -20,7 +20,7 @@ class LoaderTest extends BaseTestCase
             chdir(__DIR__);
             $config = Loader::fromPath('churn.yml', true);
 
-            $this->assertEquals(new Config(), $config);
+            $this->assertEquals(new ReadOnlyConfig(), $config);
             $this->assertEquals(\getcwd(), $config->getDirPath());
         } finally {
             // restore cwd

--- a/tests/Unit/Configuration/ReadOnlyConfigTest.php
+++ b/tests/Unit/Configuration/ReadOnlyConfigTest.php
@@ -5,21 +5,22 @@ declare(strict_types=1);
 namespace Churn\Tests\Unit\Configuration;
 
 use Churn\Configuration\Config;
+use Churn\Configuration\ReadOnlyConfig;
 use Churn\Tests\BaseTestCase;
 use InvalidArgumentException;
 
-class ConfigTest extends BaseTestCase
+class ReadOnlyConfigTest extends BaseTestCase
 {
     /** @test */
     public function it_can_be_instantiated_without_any_parameters()
     {
-        $this->assertInstanceOf(Config::class, new Config());
+        $this->assertInstanceOf(Config::class, new ReadOnlyConfig());
     }
 
     /** @test */
     public function it_returns_the_current_working_directory_by_default()
     {
-        $config = new Config();
+        $config = new ReadOnlyConfig();
 
         $this->assertSame(\getcwd(), $config->getDirPath());
     }
@@ -27,7 +28,7 @@ class ConfigTest extends BaseTestCase
     /** @test */
     public function it_returns_the_right_dir_path()
     {
-        $config = new Config('/path/to/config/file.yml');
+        $config = new ReadOnlyConfig('/path/to/config/file.yml');
 
         $this->assertSame('/path/to/config', $config->getDirPath());
     }

--- a/tests/Unit/Event/Event/AfterAnalysisEventTest.php
+++ b/tests/Unit/Event/Event/AfterAnalysisEventTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Churn\Tests\Event\Event;
 
 use Churn\Event\Event\AfterAnalysisEvent;
-use Churn\Result\ResultAccumulator;
+use Churn\Result\ResultReporter;
 use Churn\Tests\BaseTestCase;
 use Mockery as m;
 
@@ -19,7 +19,7 @@ class AfterAnalysisEventTest extends BaseTestCase
         $maxCyclomaticComplexity = 3;
         $maxScore = 0.5;
 
-        $report = m::mock(ResultAccumulator::class);
+        $report = m::mock(ResultReporter::class);
         $report->shouldReceive('getNumberOfFiles')->andReturn($numberOfFiles);
         $report->shouldReceive('getMaxCommits')->andReturn($maxNumberOfChanges);
         $report->shouldReceive('getMaxComplexity')->andReturn($maxCyclomaticComplexity);

--- a/tests/Unit/Event/Event/AfterFileAnalysisEventTest.php
+++ b/tests/Unit/Event/Event/AfterFileAnalysisEventTest.php
@@ -6,7 +6,7 @@ namespace Churn\Tests\Event\Event;
 
 use Churn\Event\Event\AfterFileAnalysisEvent;
 use Churn\File\File;
-use Churn\Result\Result;
+use Churn\Result\ResultInterface;
 use Churn\Tests\BaseTestCase;
 use Mockery as m;
 
@@ -19,9 +19,8 @@ class AfterFileAnalysisEventTest extends BaseTestCase
         $numberOfChanges = 2;
         $cyclomaticComplexity = 3;
 
-        $file = m::mock(File::class);
-        $file->shouldReceive('getFullPath')->andReturn($fullPath);
-        $result = m::mock(Result::class);
+        $file = new File($fullPath, $fullPath);
+        $result = m::mock(ResultInterface::class);
         $result->shouldReceive('getFile')->andReturn($file);
         $result->shouldReceive('getCommits')->andReturn($numberOfChanges);
         $result->shouldReceive('getComplexity')->andReturn($cyclomaticComplexity);

--- a/tests/Unit/Process/ChangesCount/NoVcsChangesCountProcessTest.php
+++ b/tests/Unit/Process/ChangesCount/NoVcsChangesCountProcessTest.php
@@ -18,9 +18,7 @@ class NoVcsChangesCountProcessTest extends BaseTestCase
 
     protected function setUp()
     {
-        $file = m::mock(File::class, [
-            'getDisplayPath' => '/foo',
-        ]);
+        $file = new File('/foo', '/foo');
         $this->process = new NoVcsChangesCountProcess($file);
     }
 

--- a/tests/Unit/Process/ConcreteProcessFactoryTest.php
+++ b/tests/Unit/Process/ConcreteProcessFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Churn\Tests\Unit\Process;
 
-use Churn\Configuration\Config;
+use Churn\Configuration\ReadOnlyConfig;
 use Churn\File\File;
 use Churn\Process\ChangesCountInterface;
 use Churn\Process\CyclomaticComplexityInterface;
@@ -21,7 +21,7 @@ class ConcreteProcessFactoryTest extends BaseTestCase
 
     public function setup()
     {
-        $config = new Config();
+        $config = new ReadOnlyConfig();
         $this->processFactory = new ConcreteProcessFactory($config->getVCS(), $config->getCommitsSince());
     }
 
@@ -74,7 +74,7 @@ class ConcreteProcessFactoryTest extends BaseTestCase
     /** @test */
     public function it_throws_exception_if_VCS_is_not_supported()
     {
-        $config = new Config();
+        $config = new ReadOnlyConfig();
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unsupported VCS: not a valid VCS');
         new ConcreteProcessFactory('not a valid VCS', $config->getCommitsSince());

--- a/tests/Unit/Process/Handler/ParallelProcessHandlerTest.php
+++ b/tests/Unit/Process/Handler/ParallelProcessHandlerTest.php
@@ -7,7 +7,7 @@ namespace Churn\Tests\Unit\Process\Handler;
 use Churn\Event\Broker;
 use Churn\File\File;
 use Churn\Process\ChangesCountInterface;
-use Churn\Process\CyclomaticComplexityProcess;
+use Churn\Process\CyclomaticComplexityInterface;
 use Churn\Process\Handler\ParallelProcessHandler;
 use Churn\Process\ConcreteProcessFactory;
 use Churn\Process\ProcessFactory;
@@ -48,7 +48,7 @@ class ParallelProcessHandlerTest extends BaseTestCase
         $process1->shouldReceive('getFile')->andReturn($file);
         $process1->shouldReceive('countChanges')->andReturn(1);
 
-        $process2 = m::mock(CyclomaticComplexityProcess::class);
+        $process2 = m::mock(CyclomaticComplexityInterface::class);
         $process2->shouldReceive('start');
         $process2->shouldReceive('isSuccessful')->andReturn(true);
         $process2->shouldReceive('getFile')->andReturn($file);

--- a/tests/Unit/Result/HighestScoresTest.php
+++ b/tests/Unit/Result/HighestScoresTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Churn\Tests\Result;
 
-use Churn\Result\Result;
+use Churn\Result\ResultInterface;
 use Churn\Result\HighestScores;
 use Churn\Tests\BaseTestCase;
 use Mockery as m;
@@ -15,9 +15,9 @@ class HighestScoresTest extends BaseTestCase
     public function it_keeps_results_sorted_by_priority()
     {
         $scores = new HighestScores(10);
-        $scores->add(m::mock(Result::class, ['getPriority' => 2]));
-        $scores->add(m::mock(Result::class, ['getPriority' => 1]));
-        $scores->add(m::mock(Result::class, ['getPriority' => 3]));
+        $scores->add(m::mock(ResultInterface::class, ['getPriority' => 2]));
+        $scores->add(m::mock(ResultInterface::class, ['getPriority' => 1]));
+        $scores->add(m::mock(ResultInterface::class, ['getPriority' => 3]));
 
         $results = $scores->toArray();
 
@@ -31,11 +31,11 @@ class HighestScoresTest extends BaseTestCase
     public function it_keeps_ony_the_highest_priorities()
     {
         $scores = new HighestScores(3);
-        $scores->add(m::mock(Result::class, ['getPriority' => 4]));
-        $scores->add(m::mock(Result::class, ['getPriority' => 2]));
-        $scores->add(m::mock(Result::class, ['getPriority' => 1]));
-        $scores->add(m::mock(Result::class, ['getPriority' => 3]));
-        $scores->add(m::mock(Result::class, ['getPriority' => 5]));
+        $scores->add(m::mock(ResultInterface::class, ['getPriority' => 4]));
+        $scores->add(m::mock(ResultInterface::class, ['getPriority' => 2]));
+        $scores->add(m::mock(ResultInterface::class, ['getPriority' => 1]));
+        $scores->add(m::mock(ResultInterface::class, ['getPriority' => 3]));
+        $scores->add(m::mock(ResultInterface::class, ['getPriority' => 5]));
 
         $results = $scores->toArray();
 

--- a/tests/Unit/Result/ResultAccumulatorTest.php
+++ b/tests/Unit/Result/ResultAccumulatorTest.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Churn\Tests\Result;
 
 use Churn\File\File;
-use Churn\Result\Result;
+use Churn\Result\ResultInterface;
 use Churn\Result\ResultAccumulator;
 use Churn\Tests\BaseTestCase;
 use Mockery as m;
 
 class ResultAccumulatorTest extends BaseTestCase
 {
-    private function mockResult(int $commits, int $complexity, string $file, float $score = 0.0): Result
+    private function mockResult(int $commits, int $complexity, string $file, float $score = 0.0): ResultInterface
     {
-        $result = m::mock(Result::class);
+        $result = m::mock(ResultInterface::class);
         $result->shouldReceive('getCommits')->andReturn($commits);
         $result->shouldReceive('getComplexity')->andReturn($complexity);
         $result->shouldReceive('getPriority')->andReturn($commits * $complexity);


### PR DESCRIPTION
There is a new PHPCS rule `RequireAbstractOrFinal` since [7.1.0](https://github.com/slevomat/coding-standard/releases/tag/7.1.0) that checks if one of those keywords are present.