### PR TITLE
Raise the min version for Mockery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.5",
-        "mockery/mockery": "^1.2.0",
+        "mockery/mockery": "^1.3.0",
         "phar-io/manifest": "^1.0 || ^2.0",
         "symfony/phpunit-bridge": "^5.1 || ^6.0"
     },


### PR DESCRIPTION
The Mockery's `1.2.x` branch is not maintained while `1.3.x` still is.