### PR TITLE
Make data providers static

### DIFF
--- a/tests/Unit/Assessor/CyclomaticComplexityAssessorTest.php
+++ b/tests/Unit/Assessor/CyclomaticComplexityAssessorTest.php
@@ -239,7 +239,7 @@ EOC;
     /**
      * @return iterable<string, array{int, string}>
      */
-    public function provide_assess(): iterable
+    public static function provide_assess(): iterable
     {
         yield 'an empty file' => [1, ''];
         yield 'an empty class' => [1, self::CODE_EMPTY_CLASS];

--- a/tests/Unit/Command/Helper/MaxScoreCheckerTest.php
+++ b/tests/Unit/Command/Helper/MaxScoreCheckerTest.php
@@ -45,7 +45,7 @@ final class MaxScoreCheckerTest extends BaseTestCase
     /**
      * @return iterable<string, array{bool, ?float, ?float}>
      */
-    public function provide_arguments(): iterable
+    public static function provide_arguments(): iterable
     {
         yield 'threshold and score are null' => [false, null, null];
         yield 'score is null' => [false, 1, null];
@@ -85,7 +85,7 @@ final class MaxScoreCheckerTest extends BaseTestCase
     /**
      * @return iterable<string, array{string, ?string, bool}>
      */
-    public function provide_format_and_output(): iterable
+    public static function provide_format_and_output(): iterable
     {
         yield 'format=text, output is null' => ['text', null, true];
         yield 'format=text, output is not null' => ['text', '/tmp', true];

--- a/tests/Unit/Configuration/Validator/CachePathTest.php
+++ b/tests/Unit/Configuration/Validator/CachePathTest.php
@@ -8,7 +8,6 @@ use Churn\Configuration\Config;
 use Churn\Configuration\EditableConfig;
 use Churn\Configuration\Validator;
 use Churn\Configuration\Validator\CachePath;
-use Churn\Tests\Unit\Configuration\ValidatorBaseTestCase;
 
 final class CachePathTest extends ValidatorBaseTestCase
 {
@@ -34,13 +33,13 @@ final class CachePathTest extends ValidatorBaseTestCase
     }
 
     /** {@inheritDoc} */
-    public function provideValidValues(): iterable
+    public static function provideValidValues(): iterable
     {
         yield 'CachePath' => ['/tmp/.churn.cache'];
     }
 
     /** {@inheritDoc} */
-    public function provideInvalidValues(): iterable
+    public static function provideInvalidValues(): iterable
     {
         yield 'CachePath / int' => [123, 'Cache path should be a string'];
     }

--- a/tests/Unit/Configuration/Validator/CommitsSinceTest.php
+++ b/tests/Unit/Configuration/Validator/CommitsSinceTest.php
@@ -7,7 +7,6 @@ namespace Churn\Tests\Unit\Configuration\Validator;
 use Churn\Configuration\Config;
 use Churn\Configuration\Validator;
 use Churn\Configuration\Validator\CommitsSince;
-use Churn\Tests\Unit\Configuration\ValidatorBaseTestCase;
 
 final class CommitsSinceTest extends ValidatorBaseTestCase
 {
@@ -46,13 +45,13 @@ final class CommitsSinceTest extends ValidatorBaseTestCase
     }
 
     /** {@inheritDoc} */
-    public function provideValidValues(): iterable
+    public static function provideValidValues(): iterable
     {
         yield 'CommitsSince' => ['4 years ago'];
     }
 
     /** {@inheritDoc} */
-    public function provideInvalidValues(): iterable
+    public static function provideInvalidValues(): iterable
     {
         yield 'CommitsSince / int' => [123, 'Commits since should be a string'];
         yield 'CommitsSince / null' => [null, 'Commits since should be a string'];

--- a/tests/Unit/Configuration/Validator/DirectoriesToScanTest.php
+++ b/tests/Unit/Configuration/Validator/DirectoriesToScanTest.php
@@ -7,7 +7,6 @@ namespace Churn\Tests\Unit\Configuration\Validator;
 use Churn\Configuration\Config;
 use Churn\Configuration\Validator;
 use Churn\Configuration\Validator\DirectoriesToScan;
-use Churn\Tests\Unit\Configuration\ValidatorBaseTestCase;
 
 final class DirectoriesToScanTest extends ValidatorBaseTestCase
 {
@@ -33,13 +32,13 @@ final class DirectoriesToScanTest extends ValidatorBaseTestCase
     }
 
     /** {@inheritDoc} */
-    public function provideValidValues(): iterable
+    public static function provideValidValues(): iterable
     {
         yield 'DirectoriesToScan' => [['src', 'tests']];
     }
 
     /** {@inheritDoc} */
-    public function provideInvalidValues(): iterable
+    public static function provideInvalidValues(): iterable
     {
         yield 'DirectoriesToScan / string' => ['foo', 'Directories to scan should be an array of strings'];
         yield 'DirectoriesToScan / null' => [null, 'Directories to scan should be an array of strings'];

--- a/tests/Unit/Configuration/Validator/FileExtensionsTest.php
+++ b/tests/Unit/Configuration/Validator/FileExtensionsTest.php
@@ -7,7 +7,6 @@ namespace Churn\Tests\Unit\Configuration\Validator;
 use Churn\Configuration\Config;
 use Churn\Configuration\Validator;
 use Churn\Configuration\Validator\FileExtensions;
-use Churn\Tests\Unit\Configuration\ValidatorBaseTestCase;
 
 final class FileExtensionsTest extends ValidatorBaseTestCase
 {
@@ -33,13 +32,13 @@ final class FileExtensionsTest extends ValidatorBaseTestCase
     }
 
     /** {@inheritDoc} */
-    public function provideValidValues(): iterable
+    public static function provideValidValues(): iterable
     {
         yield 'FileExtensions' => [['php', 'inc']];
     }
 
     /** {@inheritDoc} */
-    public function provideInvalidValues(): iterable
+    public static function provideInvalidValues(): iterable
     {
         yield 'FileExtensions / string' => ['foo', 'File extensions should be an array of strings'];
         yield 'FileExtensions / null' => [null, 'File extensions should be an array of strings'];

--- a/tests/Unit/Configuration/Validator/FilesToIgnoreTest.php
+++ b/tests/Unit/Configuration/Validator/FilesToIgnoreTest.php
@@ -7,7 +7,6 @@ namespace Churn\Tests\Unit\Configuration\Validator;
 use Churn\Configuration\Config;
 use Churn\Configuration\Validator;
 use Churn\Configuration\Validator\FilesToIgnore;
-use Churn\Tests\Unit\Configuration\ValidatorBaseTestCase;
 
 final class FilesToIgnoreTest extends ValidatorBaseTestCase
 {
@@ -33,13 +32,13 @@ final class FilesToIgnoreTest extends ValidatorBaseTestCase
     }
 
     /** {@inheritDoc} */
-    public function provideValidValues(): iterable
+    public static function provideValidValues(): iterable
     {
         yield 'FilesToIgnore' => [['foo.php', 'bar.php', 'baz.php']];
     }
 
     /** {@inheritDoc} */
-    public function provideInvalidValues(): iterable
+    public static function provideInvalidValues(): iterable
     {
         yield 'FilesToIgnore / string' => ['foo', 'Files to ignore should be an array of strings'];
         yield 'FilesToIgnore / null' => [null, 'Files to ignore should be an array of strings'];

--- a/tests/Unit/Configuration/Validator/FilesToShowTest.php
+++ b/tests/Unit/Configuration/Validator/FilesToShowTest.php
@@ -7,7 +7,6 @@ namespace Churn\Tests\Unit\Configuration\Validator;
 use Churn\Configuration\Config;
 use Churn\Configuration\Validator;
 use Churn\Configuration\Validator\FilesToShow;
-use Churn\Tests\Unit\Configuration\ValidatorBaseTestCase;
 
 final class FilesToShowTest extends ValidatorBaseTestCase
 {
@@ -33,13 +32,13 @@ final class FilesToShowTest extends ValidatorBaseTestCase
     }
 
     /** {@inheritDoc} */
-    public function provideValidValues(): iterable
+    public static function provideValidValues(): iterable
     {
         yield 'FilesToShow' => [13];
     }
 
     /** {@inheritDoc} */
-    public function provideInvalidValues(): iterable
+    public static function provideInvalidValues(): iterable
     {
         yield 'FilesToShow / string' => ['foo', 'Files to show should be an integer'];
         yield 'FilesToShow / null' => [null, 'Files to show should be an integer'];

--- a/tests/Unit/Configuration/Validator/HooksTest.php
+++ b/tests/Unit/Configuration/Validator/HooksTest.php
@@ -7,7 +7,6 @@ namespace Churn\Tests\Unit\Configuration\Validator;
 use Churn\Configuration\Config;
 use Churn\Configuration\Validator;
 use Churn\Configuration\Validator\Hooks;
-use Churn\Tests\Unit\Configuration\ValidatorBaseTestCase;
 
 final class HooksTest extends ValidatorBaseTestCase
 {
@@ -33,13 +32,13 @@ final class HooksTest extends ValidatorBaseTestCase
     }
 
     /** {@inheritDoc} */
-    public function provideValidValues(): iterable
+    public static function provideValidValues(): iterable
     {
         yield 'Hook' => [['Hook1', 'Hook2']];
     }
 
     /** {@inheritDoc} */
-    public function provideInvalidValues(): iterable
+    public static function provideInvalidValues(): iterable
     {
         yield 'Hooks / string' => ['foo', 'Hooks should be an array of strings'];
         yield 'Hooks / null' => [null, 'Hooks should be an array of strings'];

--- a/tests/Unit/Configuration/Validator/MaxScoreThresholdTest.php
+++ b/tests/Unit/Configuration/Validator/MaxScoreThresholdTest.php
@@ -8,7 +8,6 @@ use Churn\Configuration\Config;
 use Churn\Configuration\EditableConfig;
 use Churn\Configuration\Validator;
 use Churn\Configuration\Validator\MaxScoreThreshold;
-use Churn\Tests\Unit\Configuration\ValidatorBaseTestCase;
 
 final class MaxScoreThresholdTest extends ValidatorBaseTestCase
 {
@@ -34,13 +33,13 @@ final class MaxScoreThresholdTest extends ValidatorBaseTestCase
     }
 
     /** {@inheritDoc} */
-    public function provideValidValues(): iterable
+    public static function provideValidValues(): iterable
     {
         yield 'MaxScoreThreshold' => [9.5];
     }
 
     /** {@inheritDoc} */
-    public function provideInvalidValues(): iterable
+    public static function provideInvalidValues(): iterable
     {
         yield 'MaxScoreThreshold / string' => ['foo', 'Maximum score threshold should be a number'];
     }

--- a/tests/Unit/Configuration/Validator/MinScoreToShowTest.php
+++ b/tests/Unit/Configuration/Validator/MinScoreToShowTest.php
@@ -8,7 +8,6 @@ use Churn\Configuration\Config;
 use Churn\Configuration\EditableConfig;
 use Churn\Configuration\Validator;
 use Churn\Configuration\Validator\MinScoreToShow;
-use Churn\Tests\Unit\Configuration\ValidatorBaseTestCase;
 
 final class MinScoreToShowTest extends ValidatorBaseTestCase
 {
@@ -34,13 +33,13 @@ final class MinScoreToShowTest extends ValidatorBaseTestCase
     }
 
     /** {@inheritDoc} */
-    public function provideValidValues(): iterable
+    public static function provideValidValues(): iterable
     {
         yield 'MinScoreToShow' => [5.0];
     }
 
     /** {@inheritDoc} */
-    public function provideInvalidValues(): iterable
+    public static function provideInvalidValues(): iterable
     {
         yield 'MinScoreToShow / string' => ['foo', 'Minimum score to show should be a number'];
     }

--- a/tests/Unit/Configuration/Validator/ParallelJobsTest.php
+++ b/tests/Unit/Configuration/Validator/ParallelJobsTest.php
@@ -7,7 +7,6 @@ namespace Churn\Tests\Unit\Configuration\Validator;
 use Churn\Configuration\Config;
 use Churn\Configuration\Validator;
 use Churn\Configuration\Validator\ParallelJobs;
-use Churn\Tests\Unit\Configuration\ValidatorBaseTestCase;
 
 final class ParallelJobsTest extends ValidatorBaseTestCase
 {
@@ -33,13 +32,13 @@ final class ParallelJobsTest extends ValidatorBaseTestCase
     }
 
     /** {@inheritDoc} */
-    public function provideValidValues(): iterable
+    public static function provideValidValues(): iterable
     {
         yield 'ParallelJobs' => [7];
     }
 
     /** {@inheritDoc} */
-    public function provideInvalidValues(): iterable
+    public static function provideInvalidValues(): iterable
     {
         yield 'ParallelJobs / string' => ['foo', 'Amount of parallel jobs should be an integer'];
         yield 'ParallelJobs / null' => [null, 'Amount of parallel jobs should be an integer'];

--- a/tests/Unit/Configuration/Validator/ValidatorBaseTestCase.php
+++ b/tests/Unit/Configuration/Validator/ValidatorBaseTestCase.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Churn\Tests\Unit\Configuration;
+namespace Churn\Tests\Unit\Configuration\Validator;
 
 use Churn\Configuration\Config;
 use Churn\Configuration\EditableConfig;
@@ -36,12 +36,12 @@ abstract class ValidatorBaseTestCase extends BaseTestCase
     /**
      * @return iterable<string, array{mixed}>
      */
-    abstract public function provideValidValues(): iterable;
+    abstract public static function provideValidValues(): iterable;
 
     /**
      * @return iterable<string, array{mixed, string}>
      */
-    abstract public function provideInvalidValues(): iterable;
+    abstract public static function provideInvalidValues(): iterable;
 
     /** @return void */
     public function setUp()

--- a/tests/Unit/Configuration/Validator/VcsTest.php
+++ b/tests/Unit/Configuration/Validator/VcsTest.php
@@ -7,7 +7,6 @@ namespace Churn\Tests\Unit\Configuration\Validator;
 use Churn\Configuration\Config;
 use Churn\Configuration\Validator;
 use Churn\Configuration\Validator\Vcs;
-use Churn\Tests\Unit\Configuration\ValidatorBaseTestCase;
 
 final class VcsTest extends ValidatorBaseTestCase
 {
@@ -33,13 +32,13 @@ final class VcsTest extends ValidatorBaseTestCase
     }
 
     /** {@inheritDoc} */
-    public function provideValidValues(): iterable
+    public static function provideValidValues(): iterable
     {
         yield 'Vcs' => ['none'];
     }
 
     /** {@inheritDoc} */
-    public function provideInvalidValues(): iterable
+    public static function provideInvalidValues(): iterable
     {
         yield 'Vcs / int' => [123, 'VCS should be a string'];
         yield 'Vcs / null' => [null, 'VCS should be a string'];

--- a/tests/Unit/File/FileHelperTest.php
+++ b/tests/Unit/File/FileHelperTest.php
@@ -14,14 +14,16 @@ final class FileHelperTest extends BaseTestCase
     /**
      * @var array<string>
      */
-    private $filesToDelete = [];
+    private static $filesToDelete = [];
 
     /** @return void */
     protected function tearDown()
     {
         parent::tearDown();
 
-        (new Filesystem())->remove($this->filesToDelete);
+        (new Filesystem())->remove(self::$filesToDelete);
+
+        self::$filesToDelete = [];
     }
 
     /**
@@ -39,7 +41,7 @@ final class FileHelperTest extends BaseTestCase
     /**
      * @return iterable<int, array{string, string, string}>
      */
-    public function provide_absolute_paths(): iterable
+    public static function provide_absolute_paths(): iterable
     {
         yield ['/tmp', '/path', '/tmp'];
         yield ['foo', '/path', '/path/foo'];
@@ -65,7 +67,7 @@ final class FileHelperTest extends BaseTestCase
     /**
      * @return iterable<int, array{string, string, string}>
      */
-    public function provide_relative_paths(): iterable
+    public static function provide_relative_paths(): iterable
     {
         yield ['/tmp/file.php', '/tmp', 'file.php'];
         yield ['/tmp/file.php', '/tmp/', 'file.php'];
@@ -96,12 +98,12 @@ final class FileHelperTest extends BaseTestCase
     /**
      * @return iterable<int, array{string}>
      */
-    public function provide_writable_paths(): iterable
+    public static function provide_writable_paths(): iterable
     {
         yield [__FILE__];
         yield [__DIR__ . '/non-existing-file'];
 
-        $this->filesToDelete[] = __DIR__ . '/path';
+        self::$filesToDelete[] = __DIR__ . '/path';
 
         yield [__DIR__ . '/path/to/non-existing-file'];
     }
@@ -120,7 +122,7 @@ final class FileHelperTest extends BaseTestCase
     /**
      * @return iterable<int, array{string}>
      */
-    public function provide_invalid_writable_paths(): iterable
+    public static function provide_invalid_writable_paths(): iterable
     {
         yield [''];
         yield [__DIR__];

--- a/tests/Unit/Process/CacheProcessFactoryTest.php
+++ b/tests/Unit/Process/CacheProcessFactoryTest.php
@@ -30,7 +30,7 @@ final class CacheProcessFactoryTest extends BaseTestCase
     /**
      * @return iterable<int, array{string, string}>
      */
-    public function provide_invalid_paths(): iterable
+    public static function provide_invalid_paths(): iterable
     {
         yield ['', 'Path cannot be empty'];
         yield [__DIR__, 'Path cannot be a folder'];

--- a/tests/Unit/Result/ResultTest.php
+++ b/tests/Unit/Result/ResultTest.php
@@ -80,7 +80,7 @@ final class ResultTest extends BaseTestCase
     /**
      * @return iterable<string, array{Result}>
      */
-    public function provide_uncomplete_result(): iterable
+    public static function provide_uncomplete_result(): iterable
     {
         $file = new File('/filename.php', 'filename.php');
         $result = new Result($file);
@@ -114,7 +114,7 @@ final class ResultTest extends BaseTestCase
     /**
      * @return iterable<int, array{int, int}>
      */
-    public function provide_invalid_score(): iterable
+    public static function provide_invalid_score(): iterable
     {
         yield [0, 0];
         yield [0, 1];


### PR DESCRIPTION
Using a non-static method as a data provider will be deprecated from PHPUnit 10: https://github.com/sebastianbergmann/phpunit/commit/9caafe2d49b33a21f87db248a8ad6ca7c7bdac09