### PR TITLE
Fix Phar::running false positive error

### DIFF
--- a/infection.json
+++ b/infection.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/infection/infection/0.26.0/resources/schema.json",
+    "$schema": "https://raw.githubusercontent.com/infection/infection/0.26.19/resources/schema.json",
     "source": {
         "directories": [
             "src"
@@ -10,6 +10,6 @@
     },
     "mutators": {
         "@default": true,
-	"@cast": false
+        "@cast": false
     }
 }

--- a/src/Process/ConcreteProcessFactory.php
+++ b/src/Process/ConcreteProcessFactory.php
@@ -99,8 +99,12 @@ final class ConcreteProcessFactory implements ProcessFactory
     /** @return array<string> */
     private function getAssessorArguments(): array
     {
-        if (\is_callable([Phar::class, 'running']) && '' !== Phar::running(false)) {
-            return [Phar::running(false), 'assess-complexity'];
+        $fullPath = '';
+        if (\class_exists(Phar::class, false)) {
+            $fullPath = Phar::running(false);
+        }
+        if ('' !== $fullPath) {
+            return [$fullPath, 'assess-complexity'];
         }
 
         return [__DIR__ . '/../../bin/CyclomaticComplexityAssessorRunner'];


### PR DESCRIPTION
Fix the following PHPStan error:
```
Error: Left side of && is always true.
 ------ -------------------------------------------------------------------- 
  Line   src/Process/ConcreteProcessFactory.php                              
 ------ -------------------------------------------------------------------- 
  102    Left side of && is always true.                                     
         💡 Because the type is coming from a PHPDoc, you can turn off this   
            check by setting treatPhpDocTypesAsCertain: false in your        
            phpstan.neon.                                                    
 ------ -------------------------------------------------------------------- 
```