### PR TITLE
Sort keyed multi-line arrays

### DIFF
--- a/src/Assessor/CyclomaticComplexityAssessor.php
+++ b/src/Assessor/CyclomaticComplexityAssessor.php
@@ -13,21 +13,21 @@ final class CyclomaticComplexityAssessor implements Assessor
      * @var array<int, int>
      */
     private $tokens = [
+        \T_BOOLEAN_AND => 1,
+        \T_BOOLEAN_OR => 1,
+        \T_CASE => 1,
+        \T_CATCH => 1,
         \T_CLASS => 1,
-        \T_INTERFACE => 1,
-        \T_TRAIT => 1,
-        \T_IF => 1,
+        \T_COALESCE => 1,
         \T_ELSEIF => 1,
         \T_FOR => 1,
         \T_FOREACH => 1,
-        \T_WHILE => 1,
-        \T_CASE => 1,
-        \T_CATCH => 1,
-        \T_BOOLEAN_AND => 1,
+        \T_IF => 1,
+        \T_INTERFACE => 1,
         \T_LOGICAL_AND => 1,
-        \T_BOOLEAN_OR => 1,
         \T_LOGICAL_OR => 1,
-        \T_COALESCE => 1,
+        \T_TRAIT => 1,
+        \T_WHILE => 1,
     ];
 
     /**

--- a/src/Result/Render/JsonResultsRenderer.php
+++ b/src/Result/Render/JsonResultsRenderer.php
@@ -23,9 +23,9 @@ final class JsonResultsRenderer implements ResultsRendererInterface
 
         foreach ($results as $result) {
             $data[] = [
-                'file' => $result[0],
                 'commits' => $result[1],
                 'complexity' => $result[2],
+                'file' => $result[0],
                 'score' => $result[3],
             ];
         }

--- a/tests/EndToEnd/FossilTest.php
+++ b/tests/EndToEnd/FossilTest.php
@@ -39,8 +39,8 @@ final class FossilTest extends BaseTestCase
     public function it_works_with_fossil(): void
     {
         $exitCode = $this->commandTester->execute([
-            'paths' => [],
             '--configuration' => '/tmp/test',
+            'paths' => [],
         ]);
         $display = $this->commandTester->getDisplay();
 

--- a/tests/EndToEnd/MercurialTest.php
+++ b/tests/EndToEnd/MercurialTest.php
@@ -39,8 +39,8 @@ final class MercurialTest extends BaseTestCase
     public function it_works_with_mercurial(): void
     {
         $exitCode = $this->commandTester->execute([
-            'paths' => [],
             '--configuration' => '/tmp/test',
+            'paths' => [],
         ]);
         $display = $this->commandTester->getDisplay();
 

--- a/tests/EndToEnd/SubversionTest.php
+++ b/tests/EndToEnd/SubversionTest.php
@@ -39,8 +39,8 @@ final class SubversionTest extends BaseTestCase
     public function it_works_with_subversion(): void
     {
         $exitCode = $this->commandTester->execute([
-            'paths' => [],
             '--configuration' => '/tmp/test',
+            'paths' => [],
         ]);
         $display = $this->commandTester->getDisplay();
 

--- a/tests/Integration/Command/RunCommandTest.php
+++ b/tests/Integration/Command/RunCommandTest.php
@@ -58,8 +58,8 @@ final class RunCommandTest extends BaseTestCase
     public function it_displays_the_logo_at_the_beginning_by_default(): void
     {
         $exitCode = $this->commandTester->execute([
-            'paths' => [__DIR__],
             '--parallel' => '1',
+            'paths' => [__DIR__],
         ]);
         $display = $this->commandTester->getDisplay();
 
@@ -73,8 +73,8 @@ final class RunCommandTest extends BaseTestCase
     public function it_can_show_a_progress_bar(): void
     {
         $exitCode = $this->commandTester->execute([
-            'paths' => [__DIR__],
             '--progress' => null,
+            'paths' => [__DIR__],
         ]);
         $display = $this->commandTester->getDisplay();
 
@@ -100,9 +100,9 @@ final class RunCommandTest extends BaseTestCase
         self::assertNotFalse($tmpFile = \tempnam(\sys_get_temp_dir(), 'churn-test-'));
         $this->tmpFile = $tmpFile;
         $exitCode = $this->commandTester->execute([
-            'paths' => [\realpath(__DIR__ . '/../../')],
             '--format' => 'json',
             '--output' => $this->tmpFile,
+            'paths' => [\realpath(__DIR__ . '/../../')],
         ]);
         $display = $this->commandTester->getDisplay();
 
@@ -141,8 +141,8 @@ final class RunCommandTest extends BaseTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->commandTester->execute([
-            'paths' => [__DIR__],
             '--configuration' => 'not a valid configuration file',
+            'paths' => [__DIR__],
         ]);
     }
 
@@ -151,8 +151,8 @@ final class RunCommandTest extends BaseTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->commandTester->execute([
-            'paths' => [],
             '-c' => __DIR__ . '/config/empty.yml',
+            'paths' => [],
         ]);
     }
 
@@ -161,8 +161,8 @@ final class RunCommandTest extends BaseTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->commandTester->execute([
-            'paths' => [__DIR__],
             '--parallel' => 'foo',
+            'paths' => [__DIR__],
         ]);
     }
 
@@ -178,8 +178,8 @@ final class RunCommandTest extends BaseTestCase
 
         // generate cache
         self::assertSame(0, $this->commandTester->execute([
-            'paths' => [],
             '-c' => __DIR__ . '/config/test-cache.yml',
+            'paths' => [],
         ]));
         $displayBeforeCache = $this->commandTester->getDisplay();
 
@@ -187,8 +187,8 @@ final class RunCommandTest extends BaseTestCase
         self::assertGreaterThan(0, \filesize($cachePath), 'Cache file is empty');
         // use cache
         self::assertSame(0, $this->commandTester->execute([
-            'paths' => [],
             '-c' => __DIR__ . '/config/test-cache.yml',
+            'paths' => [],
         ]));
         $displayAfterCache = $this->commandTester->getDisplay();
 
@@ -203,8 +203,8 @@ final class RunCommandTest extends BaseTestCase
         TestHook::reset();
 
         $exitCode = $this->commandTester->execute([
-            'paths' => [__FILE__, __DIR__ . '/AssessComplexityCommandTest.php'],
             '-c' => __DIR__ . '/config/hook-by-classname.yml',
+            'paths' => [__FILE__, __DIR__ . '/AssessComplexityCommandTest.php'],
         ]);
 
         self::assertSame(0, $exitCode);
@@ -217,8 +217,8 @@ final class RunCommandTest extends BaseTestCase
     public function it_can_use_a_hook_by_path(): void
     {
         $exitCode = $this->commandTester->execute([
-            'paths' => [__FILE__, __DIR__ . '/AssessComplexityCommandTest.php'],
             '-c' => __DIR__ . '/config/hook-by-path.yml',
+            'paths' => [__FILE__, __DIR__ . '/AssessComplexityCommandTest.php'],
         ]);
 
         self::assertSame(0, $exitCode);
@@ -233,8 +233,8 @@ final class RunCommandTest extends BaseTestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid hook: invalid-hook');
         $this->commandTester->execute([
-            'paths' => [__FILE__, __DIR__ . '/AssessComplexityCommandTest.php'],
             '-c' => __DIR__ . '/config/hook-invalid.yml',
+            'paths' => [__FILE__, __DIR__ . '/AssessComplexityCommandTest.php'],
         ]);
     }
 
@@ -245,9 +245,9 @@ final class RunCommandTest extends BaseTestCase
 
         \ob_start();
         $exitCode = $this->commandTester->execute([
-            'paths' => [__FILE__, __DIR__ . '/AssessComplexityCommandTest.php'],
-            '-c' => __DIR__ . '/config/hook-print.yml',
             '--quiet' => null,
+            '-c' => __DIR__ . '/config/hook-print.yml',
+            'paths' => [__FILE__, __DIR__ . '/AssessComplexityCommandTest.php'],
         ]);
         $display = \ob_get_contents();
         \ob_end_clean();
@@ -260,8 +260,8 @@ final class RunCommandTest extends BaseTestCase
     public function it_can_return_one_as_exit_code(): void
     {
         $exitCode = $this->commandTester->execute([
-            'paths' => [__FILE__],
             '-c' => __DIR__ . '/config/test-threshold.yml',
+            'paths' => [__FILE__],
         ], ['capture_stderr_separately' => true]);
         $display = $this->commandTester->getErrorOutput();
 
@@ -273,8 +273,8 @@ final class RunCommandTest extends BaseTestCase
     public function it_can_warn_about_unrecognized_keys(): void
     {
         $exitCode = $this->commandTester->execute([
-            'paths' => [__FILE__],
             '-c' => __DIR__ . '/config/unrecognized-keys.yml',
+            'paths' => [__FILE__],
         ], ['capture_stderr_separately' => true]);
         $display = $this->commandTester->getErrorOutput();
 
@@ -286,9 +286,9 @@ final class RunCommandTest extends BaseTestCase
     public function it_can_return_a_json_report_with_warnings(): void
     {
         $exitCode = $this->commandTester->execute([
-            'paths' => [__DIR__],
             '--format' => 'json',
             '-c' => __DIR__ . '/config/unrecognized-keys.yml',
+            'paths' => [__DIR__],
         ], ['capture_stderr_separately' => true]);
         $display = $this->commandTester->getErrorOutput();
 

--- a/tests/Unit/Result/Render/JsonResultsRendererTest.php
+++ b/tests/Unit/Result/Render/JsonResultsRendererTest.php
@@ -24,10 +24,10 @@ final class JsonResultsRendererTest extends BaseTestCase
 
         $output = m::mock(OutputInterface::class);
         $output->shouldReceive('write')->atLeast()->once()->with(
-            '[{"file":"filename1.php","commits":5,"complexity":7,"score":0.625},{"file":"filename2.php","commits":3,'
-            . '"complexity":4,"score":0.242},{"file":"filename3.php","commits":1,"complexity":5,"score":0.08},{"file":'
-            . '"filename4.php","commits":1,"complexity":1,"score":-0.225},{"file":"filename5.php","commits":8,' .
-            '"complexity":1,"score":0.143}]'
+            '[{"commits":5,"complexity":7,"file":"filename1.php","score":0.625},{"commits":3,"complexity":4,'
+            . '"file":"filename2.php","score":0.242},{"commits":1,"complexity":5,"file":"filename3.php","score":0.08},'
+            . '{"commits":1,"complexity":1,"file":"filename4.php","score":-0.225},{"commits":8,"complexity":1,'
+            . '"file":"filename5.php","score":0.143}]'
         );
 
         (new JsonResultsRenderer())->render($output, $results);


### PR DESCRIPTION
Fix the violations that appeared with the last version of PHP Code Sniffer:
```
FILE: ...rk/churn-php/churn-php/src/Result/Render/JsonResultsRenderer.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 25 | ERROR | [x] Keyed multi-line arrays must be sorted
    |       |     alphabetically.
    |       |     (SlevomatCodingStandard.Arrays.AlphabeticallySortedByKeys.IncorrectKeyOrder)
----------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------


FILE: ...hurn-php/churn-php/src/Assessor/CyclomaticComplexityAssessor.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 15 | ERROR | [x] Keyed multi-line arrays must be sorted
    |       |     alphabetically.
    |       |     (SlevomatCodingStandard.Arrays.AlphabeticallySortedByKeys.IncorrectKeyOrder)
----------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```