### PR TITLE
Explicit Psalm settings

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -2,6 +2,8 @@
 <psalm
     autoloader="tests/psalm-autoload.php"
     errorLevel="1"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
     hideExternalErrors="true"
     phpVersion="8.0"
     resolveFromConfigFile="true"


### PR DESCRIPTION
This will make disappear these warnings:
```
Warning: "findUnusedBaselineEntry" will be defaulted to "true" in Psalm 6. You should explicitly enable or disable this setting.
Warning: "findUnusedCode" will be defaulted to "true" in Psalm 6. You should explicitly enable or disable this setting.
```