### PR TITLE
Add compatibility with Symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,17 +26,17 @@
         "ext-json": "*",
         "ext-tokenizer": "*",
         "composer-runtime-api": "^2",
-        "symfony/console": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/filesystem": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/process": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
+        "symfony/console": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/filesystem": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/process": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
         "webmozart/assert": "^1.2"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.5",
         "mockery/mockery": "^1.3.0",
         "phar-io/manifest": "^1.0 || ^2.0",
-        "symfony/phpunit-bridge": "^5.1 || ^6.0"
+        "symfony/phpunit-bridge": "^5.1 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/vendor-bin/phpmd/composer.json
+++ b/vendor-bin/phpmd/composer.json
@@ -1,5 +1,6 @@
 {
     "require-dev": {
-        "phpmd/phpmd": "^2.5"
+        "phpmd/phpmd": "^2.5",
+        "pdepend/pdepend": "<2.16"
     }
 }


### PR DESCRIPTION
I had to put a constraint on _pdepend_ because of [this issue](https://github.com/pdepend/pdepend/issues/695), but since it doesn't affect the main `composer.json` file, it won't change anything to the Churn's users.