### PR TITLE
Exclude assets from classmaps

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -154,11 +154,13 @@ jobs:
       - name: "List all coverage reports"
         run: echo coverage_reports=./coverage/$(ls -m coverage/ | sed "s/, */,.\/coverage\//g") >> $GITHUB_ENV
 
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml,${{ env.coverage_reports }}
           fail_ci_if_error: true
           verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   analysis:
     name: "Static Analysis"

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,11 @@
     "autoload-dev": {
         "psr-4": {
             "Churn\\Tests\\": "tests"
-        }
+        },
+        "exclude-from-classmap": [
+            "/tests/Unit/Assets",
+            "/tests/Unit/Assets2"
+        ]
     },
     "bin": [
         "bin/churn"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,5 +25,6 @@
     </coverage>
     <php>
         <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="1" />
+        <env name="SYMFONY_PHPUNIT_REQUIRE" value="nikic/php-parser:^4.19"/>
     </php>
 </phpunit>


### PR DESCRIPTION
`composer dump-autoload --optimize --strict-psr --no-scripts` failed with this message:
```
Class Acme\Bar located in ./tests/Unit/Assets/Bar.php does not comply with psr-4 autoloading standard (rule: Churn\Tests\ => ./tests). Skipping.
Class Acme\Baz located in ./tests/Unit/Assets/Baz.php does not comply with psr-4 autoloading standard (rule: Churn\Tests\ => ./tests). Skipping.
Class Acme\Foo located in ./tests/Unit/Assets/Foo.php does not comply with psr-4 autoloading standard (rule: Churn\Tests\ => ./tests). Skipping.
Class Acme\Qux located in ./tests/Unit/Assets/Qux.inc does not comply with psr-4 autoloading standard (rule: Churn\Tests\ => ./tests). Skipping.
Class Acme\Deep2 located in ./tests/Unit/Assets2/DeepAssets/Deep2.php does not comply with psr-4 autoloading standard (rule: Churn\Tests\ => ./tests). Skipping.
Class Acme\Deep located in ./tests/Unit/Assets2/DeepAssets/Deep.php does not comply with psr-4 autoloading standard (rule: Churn\Tests\ => ./tests). Skipping.
Class Acme\Different located in ./tests/Unit/Assets2/DeepAssets/Different.php does not comply with psr-4 autoloading standard (rule: Churn\Tests\ => ./tests). Skipping.
Class Acme\Foo2 located in ./tests/Unit/Assets2/Foo2.php does not comply with psr-4 autoloading standard (rule: Churn\Tests\ => ./tests). Skipping.
Class Acme\Qux2 located in ./tests/Unit/Assets2/Qux2.inc does not comply with psr-4 autoloading standard (rule: Churn\Tests\ => ./tests). Skipping.
```

---

Psalm also failed with this error:
```
Uncaught TypeError: PhpParser\Lexer\Emulative::__construct(): Argument #1 ($phpVersion) must be of type ?PhpParser\PhpVersion, array given, called in /home/runner/work/churn-php/churn-php/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Provider/StatementsProvider.php on line 402 and defined in /home/runner/work/churn-php/churn-php/vendor/bin/.phpunit/phpunit-9.6-1/vendor/nikic/php-parser/lib/PhpParser/Lexer/Emulative.php:38
```